### PR TITLE
Add Gradle version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,51 @@
+[versions]
+androidGradlePlugin = "8.4.0"
+kotlin = "1.9.22"
+hilt = "2.56.1"
+composeBom = "2024.05.00"
+compose = "1.6.7"
+coreKtx = "1.13.1"
+lifecycle = "2.8.1"
+activityCompose = "1.9.3"
+navigationCompose = "2.7.7"
+room = "2.7.1"
+hiltNavigationCompose = "1.2.0"
+material3 = "1.2.1"
+icons = "1.6.7"
+junit = "4.13.2"
+androidxJunit = "1.1.5"
+espressoCore = "3.6.1"
+tfliteTaskText = "0.4.4"
+
+[plugins]
+"android-application" = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+"kotlin-android" = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+"kotlin-compose" = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+"hilt" = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+
+[libraries]
+"hilt-android" = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+"hilt-compiler" = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+"androidx-hilt-navigation-compose" = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+"androidx-core-ktx" = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+"androidx-lifecycle-runtime-ktx" = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
+"androidx-activity-compose" = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+"androidx-lifecycle-viewmodel-compose" = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+"androidx-compose-bom" = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
+"androidx-ui" = { module = "androidx.compose.ui:ui", version.ref = "compose" }
+"androidx-ui-graphics" = { module = "androidx.compose.ui:ui-graphics", version.ref = "compose" }
+"androidx-ui-tooling-preview" = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
+"androidx-ui-tooling" = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+"androidx-material3" = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+"androidx-material-icons-core" = { module = "androidx.compose.material:material-icons-core", version.ref = "icons" }
+"androidx-material-icons-extended" = { module = "androidx.compose.material:material-icons-extended", version.ref = "icons" }
+"androidx-navigation-compose" = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+"androidx-room-runtime" = { module = "androidx.room:room-runtime", version.ref = "room" }
+"androidx-room-ktx" = { module = "androidx.room:room-ktx", version.ref = "room" }
+"androidx-room-compiler" = { module = "androidx.room:room-compiler", version.ref = "room" }
+"tensorflow-lite-task-text" = { module = "org.tensorflow:tensorflow-lite-task-text", version.ref = "tfliteTaskText" }
+"junit" = { module = "junit:junit", version.ref = "junit" }
+"androidx-junit" = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
+"androidx-espresso-core" = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
+"androidx-ui-test-junit4" = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
+"androidx-ui-test-manifest" = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }


### PR DESCRIPTION
## Summary
- define plugin and library versions in `gradle/libs.versions.toml`

## Testing
- `gradle help` *(fails: Plugin [id: 'org.jetbrains.kotlin.plugin.compose', version: '1.9.22'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ded4a62848324abbbf60ad3ea812e