### PR TITLE
Implement Media and Services screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ htmlcov/
 # Static & media (Django/Flask/etc.)
 staticfiles/
 media/
+!app/src/main/java/com/psy/deardiary/features/media/
 
 # Uvicorn / Gunicorn sockets
 gunicorn.sock

--- a/app/src/main/java/com/psy/deardiary/features/media/MediaScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/media/MediaScreen.kt
@@ -1,0 +1,40 @@
+package com.psy.deardiary.features.media
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MediaScreen() {
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Media") }) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Konten media akan tersedia di sini.",
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/features/services/ServicesScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/services/ServicesScreen.kt
@@ -1,0 +1,45 @@
+package com.psy.deardiary.features.services
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ServicesScreen(onNavigateToCrisisSupport: () -> Unit) {
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Layanan") }) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Daftar layanan akan ditampilkan di sini.",
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = androidx.compose.ui.Modifier.padding(top = 24.dp))
+            Button(onClick = onNavigateToCrisisSupport) {
+                Text("Butuh Bantuan Darurat")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `MediaScreen` composable under `features.media`
- add `ServicesScreen` composable under `features.services`
- unignore new `features/media` path in `.gitignore`

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684df085f84c8324b4592b1a0338f542