### PR TITLE
Support updating journal entries

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/network/JournalApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/JournalApiService.kt
@@ -10,6 +10,8 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface JournalApiService {
@@ -22,4 +24,10 @@ interface JournalApiService {
         @Query("skip") skip: Int = 0,
         @Query("limit") limit: Int = 100
     ): Response<List<JournalResponse>>
+
+    @PUT("api/v1/journal/{id}")
+    suspend fun updateJournal(
+        @Path("id") id: Int,
+        @Body journal: JournalCreateRequest
+    ): Response<JournalResponse>
 }

--- a/app/src/main/java/com/psy/deardiary/data/repository/JournalRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/JournalRepository.kt
@@ -92,23 +92,11 @@ class JournalRepository @Inject constructor(
             try {
                 val unsyncedEntries = journalDao.getUnsyncedEntries()
                 for (entry in unsyncedEntries) {
-                    // TODO: Implementasikan endpoint PUT/PATCH di backend untuk update jurnal
-                    // Saat ini, kita hanya melakukan CREATE untuk entri baru.
-                    // Jika entry memiliki remoteId dan isSynced=false, itu menandakan update yang perlu dikirim ke server.
-                    // Anda perlu menambahkan logika untuk mengirim permintaan PUT/PATCH ke server jika remoteId tidak null.
-                    // Untuk demo, kita asumsikan setiap entri unsynced (termasuk yang diupdate lokal) akan dicoba dibuat ulang di server.
-                    // Ini tidak ideal untuk update karena akan membuat duplikat di server jika remoteId sudah ada.
-                    // Solusi yang lebih baik: kirim UPDATE jika remoteId != null, dan CREATE jika remoteId == null.
-
-                    val request = entry.toJournalCreateRequest() // Ini DTO untuk CREATE
+                    val request = entry.toJournalCreateRequest()
 
                     val response = if (entry.remoteId != null) {
-                        // Jika ada remoteId, coba update entri di server (asumsi ada API update)
-                        // Perlu endpoint PUT/PATCH di JournalApiService
-                        // journalApiService.updateJournal(entry.remoteId, request) // Ini perlu diimplementasikan di JournalApiService
-                        journalApiService.createJournal(request) // Untuk saat ini, fallback ke create, akan menyebabkan duplikat/error jika tidak ditangani backend
+                        journalApiService.updateJournal(entry.remoteId, request)
                     } else {
-                        // Jika tidak ada remoteId, ini adalah entri baru, buat di server
                         journalApiService.createJournal(request)
                     }
 

--- a/backend/app/api/endpoints/journal.py
+++ b/backend/app/api/endpoints/journal.py
@@ -39,3 +39,16 @@ def read_user_journal_entries(
         db=db, owner_id=current_user.id, skip=skip, limit=limit
     )
     return entries
+
+
+@router.put("/journal/{entry_id}", response_model=schemas.JournalEntryResponse)
+async def update_journal_entry(
+        entry_id: int,
+        journal: schemas.JournalEntryUpdate,
+        db: Session = Depends(database.get_db),
+        current_user: models.User = Depends(security.get_current_user)
+):
+    """Endpoint untuk memperbarui entri jurnal yang ada."""
+    return await crud_journal.update_journal_entry(
+        db=db, entry_id=entry_id, entry_in=journal, owner_id=current_user.id
+)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -16,6 +16,11 @@ class JournalEntryBase(BaseModel):
 class JournalEntryCreate(JournalEntryBase):
     pass
 
+# Skema untuk memperbarui entri jurnal yang ada. Saat ini sama dengan
+# `JournalEntryCreate` tetapi dipisahkan untuk kejelasan API.
+class JournalEntryUpdate(JournalEntryBase):
+    pass
+
 class JournalEntryResponse(JournalEntryBase):
     id: int
     owner_id: int


### PR DESCRIPTION
## Summary
- allow journal entry updates through API
- add update CRUD function
- introduce JournalEntryUpdate schema
- enable JournalRepository to update remote entries during sync
- expose updateJournal in API service

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684df17047508324b4cdc362c86b9b72