### PR TITLE
Implement AuthRepository and move DTOs

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/AuthDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/AuthDtos.kt
@@ -6,20 +6,25 @@ package com.psy.deardiary.data.dto
 
 import com.google.gson.annotations.SerializedName
 
-// Data yang dikirim ke server saat login (cocok dengan OAuth2PasswordRequestForm di FastAPI)
-// FastAPI akan membaca 'username' dan 'password' dari form data.
-// Kita akan membuatnya secara manual saat memanggil API.
-
-// Respons yang diterima dari server setelah login berhasil
-data class TokenResponse(
-    @SerializedName("access_token")
-    val accessToken: String,
-    @SerializedName("token_type")
-    val tokenType: String
+/** Request body for user registration */
+data class RegisterRequest(
+    val email: String,
+    val password: String
 )
 
-// Respons umum untuk error dari server
+/** Request body for user login */
+data class LoginRequest(
+    val email: String,
+    val password: String
+)
+
+/** Response returned by the backend after a successful login */
+data class TokenResponse(
+    @SerializedName("access_token") val accessToken: String,
+    @SerializedName("token_type") val tokenType: String
+)
+
+/** Generic error response from the backend */
 data class ErrorResponse(
-    @SerializedName("detail")
-    val detail: String
+    @SerializedName("detail") val detail: String
 )

--- a/app/src/main/java/com/psy/deardiary/data/network/AuthApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/AuthApiService.kt
@@ -1,24 +1,11 @@
 package com.psy.deardiary.data.network
 
-import com.google.gson.annotations.SerializedName
+import com.psy.deardiary.data.dto.LoginRequest
+import com.psy.deardiary.data.dto.RegisterRequest
+import com.psy.deardiary.data.dto.TokenResponse
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
-
-data class RegisterRequest(
-    val email: String,
-    val password: String
-)
-
-data class LoginRequest(
-    val email: String,
-    val password: String
-)
-
-data class TokenResponse(
-    @SerializedName("access_token") val accessToken: String,
-    @SerializedName("token_type") val tokenType: String
-)
 
 interface AuthApiService {
     @POST("api/v1/users/register")


### PR DESCRIPTION
## Summary
- consolidate auth DTOs in a single file
- use DTOs in `AuthApiService`
- replace placeholder repository with real implementation

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684e539af0488324a40a02767d022dba