### PR TITLE
Add dark theme support

### DIFF
--- a/app/src/main/java/com/psy/deardiary/ui/theme/Theme.kt
+++ b/app/src/main/java/com/psy/deardiary/ui/theme/Theme.kt
@@ -8,6 +8,7 @@ import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
@@ -31,15 +32,30 @@ private val LightColorScheme = lightColorScheme(
     outline = Outline
 )
 
-// TODO: Definisikan DarkColorScheme di sini jika aplikasi akan mendukung mode gelap
+// Skema warna gelap menggunakan palet yang sama dengan mode terang
+private val DarkColorScheme = darkColorScheme(
+    primary = Primary,
+    onPrimary = OnPrimary,
+    primaryContainer = PrimaryContainer,
+    secondary = Secondary,
+    onSecondary = OnSecondary,
+    surface = Surface,
+    onSurface = OnSurface,
+    onSurfaceVariant = OnSurfaceVariant,
+    background = Surface,
+    onBackground = OnSurface,
+    error = Error,
+    onError = OnError,
+    outline = Outline
+)
 
 @Composable
 fun DearDiaryTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    // Saat ini kita hanya menggunakan skema warna terang
-    val colorScheme = LightColorScheme
+    // Pilih skema warna berdasarkan parameter darkTheme
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
     val view = LocalView.current
 
     if (!view.isInEditMode) {
@@ -47,8 +63,8 @@ fun DearDiaryTheme(
             val window = (view.context as Activity).window
             // Mengatur warna status bar agar sesuai dengan warna primer tema
             window.statusBarColor = colorScheme.primary.toArgb()
-            // Mengatur agar ikon di status bar (jam, baterai) berwarna gelap
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
+            // Atur warna ikon status bar berdasarkan tema
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
         }
     }
 


### PR DESCRIPTION
## Summary
- add a DarkColorScheme mirroring the light palette
- choose light/dark scheme in `DearDiaryTheme`
- toggle status bar icon color based on the active theme

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb6983a4083248a4d9f3ec452a7b8