### PR TITLE
Implement settings navigation

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/local/JournalDao.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/JournalDao.kt
@@ -31,6 +31,12 @@ interface JournalDao {
     @Update // BARU: Fungsi untuk memperbarui entri lokal, menandainya sebagai belum disinkronkan
     suspend fun updateLocalEntry(entry: JournalEntry)
 
+    @Query("DELETE FROM journal_entries")
+    suspend fun deleteAllEntries()
+
+    @Query("SELECT * FROM journal_entries")
+    suspend fun getAllEntriesOnce(): List<JournalEntry>
+
 
     @Transaction
     suspend fun upsertAll(entries: List<JournalEntry>) {

--- a/app/src/main/java/com/psy/deardiary/data/repository/JournalRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/JournalRepository.kt
@@ -114,4 +114,14 @@ class JournalRepository @Inject constructor(
             }
         }
     }
+
+    suspend fun deleteAllLocalEntries() {
+        withContext(Dispatchers.IO) {
+            journalDao.deleteAllEntries()
+        }
+    }
+
+    suspend fun getAllEntriesOnce(): List<JournalEntry> {
+        return withContext(Dispatchers.IO) { journalDao.getAllEntriesOnce() }
+    }
 }

--- a/app/src/main/java/com/psy/deardiary/features/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/settings/NotificationSettingsScreen.kt
@@ -1,0 +1,43 @@
+package com.psy.deardiary.features.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationSettingsScreen(onBackClick: () -> Unit) {
+    var remindersEnabled by remember { mutableStateOf(false) }
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Pengaturan Notifikasi") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Kembali")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Ingatkan menulis jurnal",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.weight(1f)
+            )
+            Switch(checked = remindersEnabled, onCheckedChange = { remindersEnabled = it })
+        }
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/features/settings/PrivacyPolicyScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/settings/PrivacyPolicyScreen.kt
@@ -1,0 +1,34 @@
+package com.psy.deardiary.features.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PrivacyPolicyScreen(onBackClick: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Kebijakan Privasi") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Kembali")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).padding(16.dp)) {
+            Text(
+                text = "Informasi tentang bagaimana data Anda dilindungi akan ditampilkan di sini.",
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/settings/SettingsScreen.kt
@@ -30,7 +30,9 @@ import androidx.compose.ui.text.font.FontWeight // <-- TAMBAHKAN BARIS INI
 fun SettingsScreen(
     onBackClick: () -> Unit,
     onExportData: () -> Unit,
-    onDeleteAccount: () -> Unit
+    onDeleteAccount: () -> Unit,
+    onNavigateToNotification: () -> Unit,
+    onNavigateToPrivacyPolicy: () -> Unit
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
 
@@ -91,13 +93,13 @@ fun SettingsScreen(
                 icon = Icons.Default.Notifications,
                 title = "Pengaturan Notifikasi",
                 description = "Atur pengingat untuk menulis jurnal.",
-                onClick = { /* TODO: Arahkan ke layar notifikasi */ }
+                onClick = onNavigateToNotification
             )
             SettingItem(
                 icon = Icons.Default.Policy,
                 title = "Kebijakan Privasi",
                 description = "Baca bagaimana kami melindungi datamu.",
-                onClick = { /* TODO: Tampilkan kebijakan privasi */ }
+                onClick = onNavigateToPrivacyPolicy
             )
         }
     }
@@ -145,6 +147,6 @@ private fun SettingItem(
 @Composable
 private fun SettingsScreenPreview() {
     DearDiaryTheme {
-        SettingsScreen({}, {}, {})
+        SettingsScreen({}, {}, {}, {}, {})
     }
 }

--- a/app/src/main/java/com/psy/deardiary/features/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/settings/SettingsViewModel.kt
@@ -1,0 +1,32 @@
+package com.psy.deardiary.features.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.gson.Gson
+import com.psy.deardiary.data.repository.AuthRepository
+import com.psy.deardiary.data.repository.JournalRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val journalRepository: JournalRepository
+) : ViewModel() {
+
+    fun exportData() {
+        viewModelScope.launch {
+            val entries = journalRepository.getAllEntriesOnce()
+            val json = Gson().toJson(entries)
+            println("Exported Data: $json")
+        }
+    }
+
+    fun deleteAccount() {
+        viewModelScope.launch {
+            journalRepository.deleteAllLocalEntries()
+            authRepository.logout()
+        }
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/psy/deardiary/navigation/AppNavigation.kt
@@ -16,6 +16,8 @@ import com.psy.deardiary.features.diary.JournalEditorScreen
 import com.psy.deardiary.features.main.MainScreen
 import com.psy.deardiary.features.onboarding.OnboardingScreen
 import com.psy.deardiary.features.settings.SettingsScreen
+import com.psy.deardiary.features.settings.NotificationSettingsScreen
+import com.psy.deardiary.features.settings.PrivacyPolicyScreen
 import com.psy.deardiary.features.media.MediaScreen // Import MediaScreen
 import com.psy.deardiary.features.services.ServicesScreen // Import ServicesScreen
 import com.psy.deardiary.features.growth.GrowthScreen // Import GrowthScreen
@@ -89,11 +91,22 @@ fun AppNavigation(navController: NavHostController) {
         }
 
         composable(Screen.Settings.route) {
+            val settingsViewModel: com.psy.deardiary.features.settings.SettingsViewModel = hiltViewModel()
             SettingsScreen(
                 onBackClick = { navController.popBackStack() },
-                onExportData = { /* TODO: Panggil ViewModel */ },
-                onDeleteAccount = { /* TODO: Panggil ViewModel */ }
+                onExportData = { settingsViewModel.exportData() },
+                onDeleteAccount = { settingsViewModel.deleteAccount() },
+                onNavigateToNotification = { navController.navigate(Screen.NotificationSettings.route) },
+                onNavigateToPrivacyPolicy = { navController.navigate(Screen.PrivacyPolicy.route) }
             )
+        }
+
+        composable(Screen.NotificationSettings.route) {
+            NotificationSettingsScreen(onBackClick = { navController.popBackStack() })
+        }
+
+        composable(Screen.PrivacyPolicy.route) {
+            PrivacyPolicyScreen(onBackClick = { navController.popBackStack() })
         }
 
         composable(Screen.CrisisSupport.route) {

--- a/app/src/main/java/com/psy/deardiary/navigation/Screen.kt
+++ b/app/src/main/java/com/psy/deardiary/navigation/Screen.kt
@@ -20,6 +20,8 @@ sealed class Screen(val route: String) {
 
     // Rute untuk layar-layar detail yang bisa diakses dari dalam tab
     data object Settings : Screen("settings")
+    data object NotificationSettings : Screen("notification_settings")
+    data object PrivacyPolicy : Screen("privacy_policy")
     data object CrisisSupport : Screen("crisis_support")
 
     // Rute untuk Editor Jurnal dengan argumen opsional


### PR DESCRIPTION
## Summary
- add delete/export helpers to `JournalRepository`/`JournalDao`
- create `SettingsViewModel` with export & delete logic
- implement notification and privacy policy screens
- wire view model callbacks and navigation in `SettingsScreen`
- register new screens in `AppNavigation` and `Screen`

## Testing
- `./gradlew assembleDebug` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684ed0d8529883249f829b2f2161184c