### PR TITLE
Clarify jar usage for Gradle builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,6 @@
    Atau gunakan `./gradlew installDebug` untuk langsung memasang aplikasi ke
    perangkat/emulator yang terhubung.
 
+> **Catatan:** berkas `.jar` tidak dapat dieksekusi di lingkungan ini, termasuk `gradle-wrapper.jar`. Jalankan Gradle melalui instalasi lokal atau unduh jar tersebut secara manual bila diperlukan. Berkas wrapper telah diabaikan di `.gitignore`.
+
 File APK hasil build dapat ditemukan di `app/build/outputs/apk/`.


### PR DESCRIPTION
## Summary
- document jar execution limitations in the build instructions

## Testing
- `./gradlew --version` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684edaaf6e4c8324851f83d08ae6cecd