### PR TITLE
Fix service colors with MaterialTheme

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/services/ServicesScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/services/ServicesScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -57,7 +58,14 @@ fun ServicesScreen(
                     )
                 }
                 items(uiState.availableTests) { serviceItem ->
-                    ServiceCard(service = serviceItem, onClick = {
+                    ServiceCard(
+                        service = serviceItem,
+                        color = if (serviceItem.title.contains("MBTI", ignoreCase = true)) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.secondary
+                        },
+                        onClick = {
                         when {
                             serviceItem.title.contains("MBTI", ignoreCase = true) -> {
                                 navController.navigate(Screen.MbtiTest.route)
@@ -66,7 +74,8 @@ fun ServicesScreen(
                                 navController.navigate(Screen.DassTest.route)
                             }
                         }
-                    })
+                        }
+                    )
                 }
 
                 // --- Bagian: Bantuan Profesional ---
@@ -79,9 +88,13 @@ fun ServicesScreen(
                     )
                 }
                 items(uiState.professionalServices) { serviceItem ->
-                    ServiceCard(service = serviceItem, onClick = {
-                        // TODO: Navigasi ke direktori layanan profesional
-                    })
+                    ServiceCard(
+                        service = serviceItem,
+                        color = Color(0xFFffb4a2),
+                        onClick = {
+                            // TODO: Navigasi ke direktori layanan profesional
+                        }
+                    )
                 }
             }
 
@@ -101,11 +114,11 @@ fun ServicesScreen(
 }
 
 @Composable
-fun ServiceCard(service: ServiceItem, onClick: () -> Unit) {
+fun ServiceCard(service: ServiceItem, color: Color, onClick: () -> Unit) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         onClick = onClick,
-        colors = CardDefaults.cardColors(containerColor = service.color.copy(alpha = 0.2f))
+        colors = CardDefaults.cardColors(containerColor = color.copy(alpha = 0.2f))
     ) {
         Row(
             modifier = Modifier.padding(16.dp),

--- a/app/src/main/java/com/psy/deardiary/features/services/ServicesViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/services/ServicesViewModel.kt
@@ -3,10 +3,7 @@
 
 package com.psy.deardiary.features.services
 
-import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
-import com.psy.deardiary.ui.theme.Primary
-import com.psy.deardiary.ui.theme.Secondary
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,8 +13,7 @@ import javax.inject.Inject
 data class ServiceItem(
     val title: String,
     val description: String,
-    val icon: String, // Emoji
-    val color: Color
+    val icon: String // Emoji
 )
 
 // State untuk ServicesScreen
@@ -35,22 +31,19 @@ class ServicesViewModel @Inject constructor() : ViewModel() {
                 ServiceItem(
                     title = "Tes Kepribadian (MBTI)",
                     description = "Pahami tipe kepribadianmu lebih dalam.",
-                    icon = "🧠",
-                    color = Primary
+                    icon = "🧠"
                 ),
                 ServiceItem(
                     title = "Tes Tingkat Stres (DASS-21)",
                     description = "Ukur tingkat depresi, kecemasan, dan stres.",
-                    icon = "😥",
-                    color = Secondary
+                    icon = "😥"
                 )
             ),
             professionalServices = listOf(
                 ServiceItem(
                     title = "Direktori Psikolog",
                     description = "Temukan bantuan profesional di dekatmu.",
-                    icon = "👩‍⚕️",
-                    color = Color(0xFFffb4a2)
+                    icon = "👩‍⚕️"
                 )
             )
         )


### PR DESCRIPTION
## Summary
- replace hard-coded colors in `ServicesViewModel`
- provide card colors from `MaterialTheme` in `ServicesScreen`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f86d099688324847f79af3b26fa7e