### PR TITLE
Add dynamic color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,18 @@
 > **Catatan:** berkas `.jar` tidak dapat dieksekusi di lingkungan ini, termasuk `gradle-wrapper.jar`. Jalankan Gradle melalui instalasi lokal atau unduh jar tersebut secara manual bila diperlukan. Berkas wrapper telah diabaikan di `.gitignore`.
 
 File APK hasil build dapat ditemukan di `app/build/outputs/apk/`.
+
+### Kustomisasi Warna Tema
+
+Pada Android 12 (API 31) ke atas aplikasi otomatis mengikuti Dynamic Color
+dari perangkat. Untuk perangkat yang belum mendukung fitur tersebut,
+`DearDiaryTheme` akan membuat skema warna dari *seed color* merek.
+Secara bawaan nilai ini menggunakan konstanta `Primary` dari `Color.kt`.
+Anda dapat menyesuaikan warna merek dengan memberikan parameter
+`seedColor` ketika memanggil `DearDiaryTheme`:
+
+```kotlin
+DearDiaryTheme(seedColor = Color(0xFF6750A4)) {
+    // konten
+}
+```

--- a/app/src/main/java/com/psy/deardiary/ui/theme/Theme.kt
+++ b/app/src/main/java/com/psy/deardiary/ui/theme/Theme.kt
@@ -5,13 +5,19 @@
 package com.psy.deardiary.ui.theme
 
 import android.app.Activity
+import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.colorSchemeFromSeed
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -60,10 +66,21 @@ private val DarkColorScheme = darkColorScheme(
 @Composable
 fun DearDiaryTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    seedColor: Color = Primary,
     content: @Composable () -> Unit
 ) {
-    // Pilih skema warna berdasarkan parameter darkTheme
-    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+    val context = LocalContext.current
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        dynamicColor -> {
+            colorSchemeFromSeed(seedColor = seedColor, darkTheme = darkTheme)
+        }
+        else -> if (darkTheme) DarkColorScheme else LightColorScheme
+    }
+
     val view = LocalView.current
 
     if (!view.isInEditMode) {


### PR DESCRIPTION
## Summary
- use dynamic or seed-based color schemes in `DearDiaryTheme`
- document theme color customization

## Testing
- `./gradlew assembleDebug` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684f88272888832481908f49f9d20484