### PR TITLE
Refine diary features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## ✨ Fitur Utama
 
 ### 🏠 Tab Beranda
-- **Quick Input Card**: Tulis jurnal harian dengan mudah melalui kartu input intuitif, mirip gaya Facebook.
+- **Catatan Singkat**: Tulis pesan pendek tanpa judul seperti di Twitter melalui panel input cepat.
 - **Feed Jurnal Harian**: Tampilkan riwayat jurnal Anda dengan desain yang rapi dan nyaman dibaca.
 - **Pengaturan Cepat**: Akses pengaturan aplikasi langsung dari layar utama.
 
@@ -19,6 +19,7 @@
 - **Musik & Suara Alam**: Playlist relaksasi untuk membantu meditasi dan mengurangi stres.
 - **Artikel & Blog**: Artikel bermanfaat terkait kesehatan mental dari sumber tepercaya.
 - **Jurnal Terpandu**: Prompt khusus yang memandu pengguna ketika kesulitan menulis jurnal.
+- **Menulis Jurnal Panjang**: Akses editor penuh untuk menulis essai atau blog pribadi.
 
 ### ❤️ Tab Layanan
 - **Tes Psikologi**:

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.outlined.CrisisAlert
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.*
@@ -29,7 +28,6 @@ import com.psy.deardiary.features.home.components.WelcomeCard
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun HomeScreen(
-    onNavigateToEditor: () -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateToCrisisSupport: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
@@ -51,12 +49,10 @@ fun HomeScreen(
                 }
             )
         },
-        floatingActionButton = {
-            // FAB ini untuk membuka editor JURNAL LENGKAP
-            FloatingActionButton(onClick = onNavigateToEditor) {
-                Icon(Icons.Default.Edit, "Tulis Jurnal Lengkap")
-            }
-        },
+        /*
+         * Tidak ada tombol untuk menulis jurnal panjang di tab Beranda.
+         * Pengguna hanya dapat membuat catatan singkat di sini.
+         */
         bottomBar = {
             // Komponen ini untuk panel input CATATAN SINGKAT
             QuickEntryInput(
@@ -90,7 +86,7 @@ fun HomeScreen(
                             )
                             is FeedItem.PromptItem -> PromptCard(
                                 prompt = item.promptText,
-                                onWriteClick = onNavigateToEditor
+                                onNoteClick = { isQuickEntryVisible = true }
                             )
                             is FeedItem.JournalItem -> JournalItemCard(item.journalEntry)
                             is FeedItem.ArticleSuggestionItem -> ArticleSuggestionCard(item.article)

--- a/app/src/main/java/com/psy/deardiary/features/home/components/FeedCards.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/components/FeedCards.kt
@@ -47,7 +47,7 @@ fun WelcomeCard(
 }
 
 @Composable
-fun PromptCard(prompt: String, onWriteClick: () -> Unit) {
+fun PromptCard(prompt: String, onNoteClick: () -> Unit) {
     OutlinedCard(modifier = Modifier
         .fillMaxWidth()
         .padding(vertical = 8.dp)) {
@@ -61,8 +61,8 @@ fun PromptCard(prompt: String, onWriteClick: () -> Unit) {
             Spacer(modifier = Modifier.height(8.dp))
             Text(prompt, style = MaterialTheme.typography.bodyLarge, textAlign = TextAlign.Center)
             Spacer(modifier = Modifier.height(16.dp))
-            FilledTonalButton(onClick = onWriteClick) {
-                Text("Tulis Jurnal Lengkap")
+            FilledTonalButton(onClick = onNoteClick) {
+                Text("Tulis Catatan Singkat")
             }
         }
     }

--- a/app/src/main/java/com/psy/deardiary/features/main/MainScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/main/MainScreen.kt
@@ -73,16 +73,18 @@ fun MainScreen(
             // ▼▼▼ CHECKPOINT 3: Pastikan composable ini untuk Screen.Home.route dan memanggil HomeScreen ▼▼▼
             composable(Screen.Home.route) {
                 HomeScreen(
-                    onNavigateToEditor = { mainNavController.navigate(Screen.Editor.createRoute(null)) },
                     onNavigateToSettings = { mainNavController.navigate(Screen.Settings.route) },
                     onNavigateToCrisisSupport = { mainNavController.navigate(Screen.CrisisSupport.route) }
                 )
             }
             composable(Screen.Media.route) {
-                MediaScreen(onNavigateToEditorWithPrompt = { prompt ->
-                    val encodedPrompt = URLEncoder.encode(prompt, "UTF-8")
-                    mainNavController.navigate(Screen.Editor.createRoute(prompt = encodedPrompt))
-                })
+                MediaScreen(
+                    onNavigateToEditor = { mainNavController.navigate(Screen.Editor.createRoute(null)) },
+                    onNavigateToEditorWithPrompt = { prompt ->
+                        val encodedPrompt = URLEncoder.encode(prompt, "UTF-8")
+                        mainNavController.navigate(Screen.Editor.createRoute(prompt = encodedPrompt))
+                    }
+                )
             }
             composable(Screen.Services.route) {
                 ServicesScreen(navController = mainNavController)

--- a/app/src/main/java/com/psy/deardiary/features/media/MediaScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/media/MediaScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -212,13 +213,19 @@ private fun ArticleCard(article: Article, modifier: Modifier = Modifier) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MediaScreen(
+    onNavigateToEditor: () -> Unit,
     onNavigateToEditorWithPrompt: (String) -> Unit,
     viewModel: MediaViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
     Scaffold(
-        topBar = { TopAppBar(title = { Text("Media & Inspirasi") }) }
+        topBar = { TopAppBar(title = { Text("Media & Inspirasi") }) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onNavigateToEditor) {
+                Icon(Icons.Default.Edit, contentDescription = "Tulis Jurnal Panjang")
+            }
+        }
     ) { padding ->
         LazyColumn(
             modifier = Modifier
@@ -258,6 +265,6 @@ fun MediaScreen(
 @Composable
 private fun MediaScreenPreview() {
     DearDiaryTheme {
-        MediaScreen(onNavigateToEditorWithPrompt = {})
+        MediaScreen(onNavigateToEditor = {}, onNavigateToEditorWithPrompt = {})
     }
 }


### PR DESCRIPTION
## Summary
- remove long diary actions from `HomeScreen`
- adjust prompt card for quick note usage
- add diary FAB in `MediaScreen`
- wire new callbacks in `MainScreen`
- update docs about quick notes and long journals

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68518b9079d0832481c2a6d5a7e95e5b