### PR TITLE
Enhance quick entry with emoji picker

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
@@ -53,13 +53,13 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun saveQuickNote(content: String) {
+    fun saveQuickNote(content: String, mood: String = "\uD83D\uDE10") {
         viewModelScope.launch {
             if (content.isNotBlank()) {
                 journalRepository.createJournal(
                     title = "", // Judul kosong menandakan Quick Entry
                     content = content,
-                    mood = "😐",
+                    mood = mood,
                     voiceNotePath = null
                 )
             }


### PR DESCRIPTION
## Summary
- extend `QuickEntryInput` with activation state and emoji picker
- pass emoji to `HomeViewModel.saveQuickNote`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685197ac98fc8324b7f9c041ffd0483e