### PR TITLE
Add structured mood emoji list

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/EmojiOption.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/EmojiOption.kt
@@ -1,0 +1,14 @@
+package com.psy.deardiary.features.home
+
+data class EmojiOption(val emoji: String, val label: String)
+
+const val NEUTRAL_EMOJI = "\uD83D\uDE10" // grey neutral face
+
+val emojiOptions = listOf(
+    EmojiOption("\uD83D\uDE00", "Sangat Senang"),
+    EmojiOption("\uD83D\uDE42", "Senang"),
+    EmojiOption(NEUTRAL_EMOJI, "Netral"),
+    EmojiOption("\uD83D\uDE22", "Sedih"),
+    EmojiOption("\uD83D\uDE21", "Marah")
+)
+

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -110,7 +110,7 @@ private fun QuickEntryInput(
     onCloseRequest: () -> Unit
 ) {
     var text by remember { mutableStateOf("") }
-    var mood by remember { mutableStateOf("\uD83D\uDE10") }
+    var mood by remember { mutableStateOf(NEUTRAL_EMOJI) }
     var showEmojiPicker by remember { mutableStateOf(false) }
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
@@ -122,7 +122,7 @@ private fun QuickEntryInput(
         } else {
             // Membersihkan teks dan pilihan saat panel ditutup
             text = ""
-            mood = "\uD83D\uDE10"
+            mood = NEUTRAL_EMOJI
         }
     }
 
@@ -162,11 +162,17 @@ private fun QuickEntryInput(
                     Text(mood)
                 }
                 DropdownMenu(expanded = showEmojiPicker, onDismissRequest = { showEmojiPicker = false }) {
-                    listOf("😀", "🙂", "😐", "😢", "😡").forEach { emoji ->
+                    emojiOptions.forEach { option ->
                         DropdownMenuItem(
-                            text = { Text(emoji) },
+                            text = {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(option.emoji)
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(option.label)
+                                }
+                            },
                             onClick = {
-                                mood = emoji
+                                mood = option.emoji
                                 showEmojiPicker = false
                             }
                         )

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
@@ -53,7 +53,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun saveQuickNote(content: String, mood: String = "\uD83D\uDE10") {
+    fun saveQuickNote(content: String, mood: String = NEUTRAL_EMOJI) {
         viewModelScope.launch {
             if (content.isNotBlank()) {
                 journalRepository.createJournal(


### PR DESCRIPTION
## Summary
- create `EmojiOption` data class with emoji labels
- add neutral emoji constant and list of emoji options
- show emoji label next to icon in quick entry dropdown
- default quick entry mood uses the neutral emoji

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68519c7ad4f08324a70141f39cfce99d