### PR TITLE
Update QuickNote mood handling

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
@@ -56,10 +56,11 @@ class HomeViewModel @Inject constructor(
     fun saveQuickNote(content: String, mood: String = NEUTRAL_EMOJI) {
         viewModelScope.launch {
             if (content.isNotBlank()) {
+                val sanitizedMood = if (mood == NEUTRAL_EMOJI) "" else mood
                 journalRepository.createJournal(
                     title = "", // Judul kosong menandakan Quick Entry
                     content = content,
-                    mood = mood,
+                    mood = sanitizedMood,
                     voiceNotePath = null
                 )
             }


### PR DESCRIPTION
## Summary
- make `saveQuickNote` omit mood when the neutral emoji is selected

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68519d95f11c8324abe0d4a6639a4511