### PR TITLE
Add animations for chat messages

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
@@ -1,6 +1,7 @@
 package com.psy.deardiary.data.model
 
 data class ChatMessage(
+    val id: Int,
     val text: String,
     val isUser: Boolean
 )

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -15,6 +15,7 @@ class ChatRepository @Inject constructor(
     private val chatApiService: ChatApiService
 ) {
     private val history = mutableListOf<ChatMessage>()
+    private var nextId = 0
 
     fun getConversation(): List<ChatMessage> = history
 
@@ -24,8 +25,8 @@ class ChatRepository @Inject constructor(
                 val response = chatApiService.sendMessage(ChatRequest(text))
                 if (response.isSuccessful && response.body() != null) {
                     val reply = response.body()!!.reply
-                    history.add(ChatMessage(text, true))
-                    history.add(ChatMessage(reply, false))
+                    history.add(ChatMessage(nextId++, text, true))
+                    history.add(ChatMessage(nextId++, reply, false))
                     Result.Success(history.toList())
                 } else {
                     Result.Error("${'$'}{response.message()}")

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
@@ -86,8 +87,17 @@ fun HomeScreen(
                             is FeedItem.ArticleSuggestionItem -> ArticleSuggestionCard(item.article)
                         }
                     }
-                    items(messages, key = { it.hashCode() }) { msg ->
-                        ChatBubble(msg)
+                    items(messages, key = { it.id }) { msg ->
+                        AnimatedVisibility(
+                            visible = true,
+                            enter = fadeIn() + slideInVertically { it / 2 },
+                            exit = fadeOut() + slideOutVertically()
+                        ) {
+                            ChatBubble(
+                                message = msg,
+                                modifier = Modifier.animateItemPlacement()
+                            )
+                        }
                     }
                 }
             }
@@ -168,9 +178,9 @@ private fun ChatInputBar(onSend: (String) -> Unit) {
 }
 
 @Composable
-private fun ChatBubble(message: ChatMessage) {
+private fun ChatBubble(message: ChatMessage, modifier: Modifier = Modifier) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
         horizontalArrangement = if (message.isUser) Arrangement.End else Arrangement.Start


### PR DESCRIPTION
## Summary
- add `id` to `ChatMessage` for stable keys
- update repository to use incremental ids
- animate chat messages using `AnimatedVisibility` and `animateItemPlacement`

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6851ed63d9f48324ac0e86d55cad8e3c