### PR TITLE
Add placeholder flag to chat messages

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
@@ -3,5 +3,6 @@ package com.psy.deardiary.data.model
 data class ChatMessage(
     val id: Int,
     val text: String,
-    val isUser: Boolean
+    val isUser: Boolean,
+    val isPlaceholder: Boolean = false
 )

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -19,8 +19,8 @@ class ChatRepository @Inject constructor(
 
     fun getConversation(): List<ChatMessage> = history
 
-    fun addMessage(text: String, isUser: Boolean): ChatMessage {
-        val message = ChatMessage(nextId++, text, isUser)
+    fun addMessage(text: String, isUser: Boolean, isPlaceholder: Boolean = false): ChatMessage {
+        val message = ChatMessage(nextId++, text, isUser, isPlaceholder)
         history.add(message)
         return message
     }

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -32,7 +32,8 @@ class HomeChatViewModel @Inject constructor(
             // 2. Sisipkan pesan sementara sebagai indikator mengetik
             val placeholder = chatRepository.addMessage(
                 "Sedang mengetik jawaban...",
-                isUser = false
+                isUser = false,
+                isPlaceholder = true
             )
 
             // Perbarui UI segera agar placeholder terlihat


### PR DESCRIPTION
## Summary
- mark chat messages with an optional `isPlaceholder` flag
- extend repository to store placeholder state
- pass `isPlaceholder` when inserting the typing indicator

## Testing
- `./gradlew assembleDebug` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6851fce5e9708324b5d26aa4c6ab206b