### PR TITLE
Update chat delay comment

### DIFF
--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -16,7 +16,9 @@ async def chat_with_ai(
     current_user: models.User = Depends(deps.get_current_user),
 ):
     """Return a short AI reply based on user's message and context.
-    Adds a small delay to mimic typing behavior."""
+    Adds a short delay to mimic typing behavior. This delay can be
+    removed or shortened once the client implements its own waiting
+    logic so responses remain snappy."""
     journals = crud.journal.get_multi_by_owner(db, owner_id=current_user.id, limit=5)
     context_lines = [j.content for j in journals]
     moods: dict[str, int] = {}
@@ -30,5 +32,8 @@ async def chat_with_ai(
     reply = await get_ai_reply(chat_in.message, context=context)
     if reply is None:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="AI service error")
+    # Artificial delay gives the impression that the AI is "typing".
+    # Consider shortening or removing this once the client has proper
+    # waiting logic to avoid unnecessary latency.
     await asyncio.sleep(2)
     return schemas.ChatResponse(reply=reply)


### PR DESCRIPTION
## Summary
- document why `asyncio.sleep(2)` is present
- note that the delay can be shortened or removed when the client manages waiting itself

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851fe9ff74c83249221709b67270540