### PR TITLE
Improve typing indicator for chat

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.icons.outlined.EmojiEmotions
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -186,16 +185,7 @@ private fun ChatBubble(message: ChatMessage, modifier: Modifier = Modifier) {
             .padding(vertical = 4.dp),
         horizontalArrangement = if (message.isUser) Arrangement.End else Arrangement.Start
     ) {
-        var dots by remember(message.id) { mutableStateOf(".") }
-
-        if (message.isPlaceholder) {
-            LaunchedEffect(message.id) {
-                while (true) {
-                    delay(500)
-                    dots = if (dots.length >= 5) "." else dots + "."
-                }
-            }
-        }
+        // Remove old dot-based placeholder animation in favor of TypingIndicator
 
         val bubbleColor = when {
             message.isPlaceholder -> Color.Gray.copy(alpha = 0.5f)
@@ -203,16 +193,18 @@ private fun ChatBubble(message: ChatMessage, modifier: Modifier = Modifier) {
             else -> MaterialTheme.colorScheme.surfaceVariant
         }
 
-        val displayText = if (message.isPlaceholder) dots else message.text
-
         Surface(
             color = bubbleColor,
             shape = MaterialTheme.shapes.medium
         ) {
-            Text(
-                text = displayText,
-                modifier = Modifier.padding(8.dp)
-            )
+            if (message.isPlaceholder) {
+                TypingIndicator(modifier = Modifier.padding(8.dp))
+            } else {
+                Text(
+                    text = message.text,
+                    modifier = Modifier.padding(8.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/psy/deardiary/features/home/components/TypingIndicator.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/components/TypingIndicator.kt
@@ -1,0 +1,78 @@
+package com.psy.deardiary.features.home.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TypingIndicator(
+    modifier: Modifier = Modifier,
+    dotColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    dotSize: Dp = 6.dp,
+    space: Dp = 4.dp
+) {
+    val transition = rememberInfiniteTransition(label = "typing")
+
+    val alpha1 by transition.animateFloat(
+        initialValue = 0.3f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            tween(600),
+            repeatMode = RepeatMode.Reverse
+        ), label = "alpha1"
+    )
+
+    val alpha2 by transition.animateFloat(
+        initialValue = 0.3f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            tween(600, delayMillis = 150),
+            repeatMode = RepeatMode.Reverse
+        ), label = "alpha2"
+    )
+
+    val alpha3 by transition.animateFloat(
+        initialValue = 0.3f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            tween(600, delayMillis = 300),
+            repeatMode = RepeatMode.Reverse
+        ), label = "alpha3"
+    )
+
+    Row(modifier = modifier) {
+        Dot(alpha = alpha1, color = dotColor, size = dotSize)
+        Spacer(Modifier.width(space))
+        Dot(alpha = alpha2, color = dotColor, size = dotSize)
+        Spacer(Modifier.width(space))
+        Dot(alpha = alpha3, color = dotColor, size = dotSize)
+    }
+}
+
+@Composable
+private fun Dot(alpha: Float, color: Color, size: Dp) {
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(color.copy(alpha = alpha))
+    )
+}
+


### PR DESCRIPTION
## Summary
- add TypingIndicator composable
- show TypingIndicator instead of dot text placeholder in ChatBubble

## Testing
- `gradle -p app assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852014d10748324a7698d4562e459bb