### PR TITLE
Increase AI chat timeout

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -39,8 +39,8 @@ class HomeChatViewModel @Inject constructor(
             // Perbarui UI segera agar placeholder terlihat
             _messages.value = chatRepository.getConversation()
 
-            // 3. Panggil API dengan batas waktu lima detik
-            val result = withTimeoutOrNull(5_000) { chatRepository.fetchReply(text) }
+            // 3. Panggil API dengan batas waktu sepuluh detik
+            val result = withTimeoutOrNull(10_000) { chatRepository.fetchReply(text) }
 
             // 4. Ganti pesan placeholder dengan hasil atau pesan kesalahan
             when (result) {

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -32,8 +32,5 @@ async def chat_with_ai(
     reply = await get_ai_reply(chat_in.message, context=context)
     if reply is None:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="AI service error")
-    # Artificial delay gives the impression that the AI is "typing".
-    # Consider shortening or removing this once the client has proper
-    # waiting logic to avoid unnecessary latency.
-    await asyncio.sleep(2)
+    # Removed artificial delay to improve responsiveness.
     return schemas.ChatResponse(reply=reply)


### PR DESCRIPTION
## Summary
- extend chat timeout to 10 seconds
- remove artificial delay from chat endpoint

## Testing
- `./gradlew test` *(fails: Could not find Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68520843f2d88324b76e1b61472bcba6