### PR TITLE
Ensure placeholder messages cleared when replaced

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -28,7 +28,7 @@ class ChatRepository @Inject constructor(
     fun replaceMessage(id: Int, newText: String) {
         val index = history.indexOfFirst { it.id == id }
         if (index != -1) {
-            history[index] = history[index].copy(text = newText)
+            history[index] = history[index].copy(text = newText, isPlaceholder = false)
         }
     }
 


### PR DESCRIPTION
## Summary
- fix `ChatRepository.replaceMessage` so replacements clear `isPlaceholder`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520aa3decc83248fde7a9193f79e18