### PR TITLE
Ensure chat updates trigger recomposition

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -17,7 +17,7 @@ class ChatRepository @Inject constructor(
     private val history = mutableListOf<ChatMessage>()
     private var nextId = 0
 
-    fun getConversation(): List<ChatMessage> = history
+    fun getConversation(): List<ChatMessage> = history.toList()
 
     fun addMessage(text: String, isUser: Boolean, isPlaceholder: Boolean = false): ChatMessage {
         val message = ChatMessage(nextId++, text, isUser, isPlaceholder)

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -28,6 +28,8 @@ class HomeChatViewModel @Inject constructor(
         viewModelScope.launch {
             // 1. Tambahkan pesan pengguna ke history
             chatRepository.addMessage(text, isUser = true)
+            // Perbarui UI setelah menambahkan pesan pengguna
+            _messages.value = chatRepository.getConversation()
 
             // 2. Sisipkan pesan sementara sebagai indikator mengetik
             val placeholder = chatRepository.addMessage(


### PR DESCRIPTION
## Summary
- return a new list from `ChatRepository.getConversation`
- update `HomeChatViewModel` state after each change

## Testing
- `gradle test` *(fails: Could not download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68520c34b5b48324941b35ad02c63eed