### PR TITLE
Extend chat reply timeout

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -41,8 +41,10 @@ class HomeChatViewModel @Inject constructor(
             // Perbarui UI segera agar placeholder terlihat
             _messages.value = chatRepository.getConversation()
 
-            // 3. Panggil API dengan batas waktu sepuluh detik
-            val result = withTimeoutOrNull(10_000) { chatRepository.fetchReply(text) }
+            // 3. Panggil API dengan batas waktu lebih lama agar server punya waktu
+            //    yang cukup untuk merespons. Batas lama sebelumnya kadang terlalu
+            //    singkat sehingga balasan AI tidak sempat diterima sepenuhnya.
+            val result = withTimeoutOrNull(30_000) { chatRepository.fetchReply(text) }
 
             // 4. Ganti pesan placeholder dengan hasil atau pesan kesalahan
             when (result) {


### PR DESCRIPTION
## Summary
- allow server more time to respond by waiting 30s before failing

## Testing
- `./gradlew test --quiet` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520d1309fc832480361c381c9ec061