### PR TITLE
Fix sentiment tasks session usage

### DIFF
--- a/backend/app/api/v1/endpoints/journal.py
+++ b/backend/app/api/v1/endpoints/journal.py
@@ -5,77 +5,92 @@ from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from sqlalchemy.orm import Session
 from app import crud, models, schemas
 from app.api import deps
-import asyncio
 
 router = APIRouter()
 
+
 @router.post("/", response_model=schemas.Journal, status_code=status.HTTP_201_CREATED)
 def create_journal(
-        *,
-        db: Session = Depends(deps.get_db),
-        background_tasks: BackgroundTasks,
-        journal_in: schemas.JournalCreate,
-        current_user: models.User = Depends(deps.get_current_user),
+    *,
+    db: Session = Depends(deps.get_db),
+    background_tasks: BackgroundTasks,
+    journal_in: schemas.JournalCreate,
+    current_user: models.User = Depends(deps.get_current_user),
 ):
     """Membuat entri jurnal baru dan memicu analisis sentimen di latar belakang."""
-    journal = crud.journal.create_with_owner(db=db, obj_in=journal_in, owner_id=current_user.id)
+    journal = crud.journal.create_with_owner(
+        db=db, obj_in=journal_in, owner_id=current_user.id
+    )
 
     background_tasks.add_task(
-        asyncio.run, crud.journal.process_and_update_sentiment(db=db, journal_id=journal.id)
+        crud.journal.process_and_update_sentiment, journal_id=journal.id
     )
 
     return journal
 
+
 @router.get("/", response_model=List[schemas.Journal])
 def read_journals(
-        # --- PERBAIKAN: Memastikan semua parameter ada di sini ---
-        db: Session = Depends(deps.get_db),
-        skip: int = 0,
-        limit: int = 100,
-        current_user: models.User = Depends(deps.get_current_user),
-        # --- AKHIR PERBAIKAN ---
+    # --- PERBAIKAN: Memastikan semua parameter ada di sini ---
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: models.User = Depends(deps.get_current_user),
+    # --- AKHIR PERBAIKAN ---
 ):
     """Membaca semua entri jurnal milik pengguna yang sedang login."""
-    journals = crud.journal.get_multi_by_owner(db, owner_id=current_user.id, skip=skip, limit=limit)
+    journals = crud.journal.get_multi_by_owner(
+        db, owner_id=current_user.id, skip=skip, limit=limit
+    )
     return journals
+
 
 @router.put("/{id}", response_model=schemas.Journal)
 def update_journal(
-        *,
-        db: Session = Depends(deps.get_db),
-        background_tasks: BackgroundTasks,
-        id: int,
-        journal_in: schemas.JournalUpdate,
-        current_user: models.User = Depends(deps.get_current_user),
+    *,
+    db: Session = Depends(deps.get_db),
+    background_tasks: BackgroundTasks,
+    id: int,
+    journal_in: schemas.JournalUpdate,
+    current_user: models.User = Depends(deps.get_current_user),
 ):
     """Memperbarui entri jurnal dan memicu analisis sentimen ulang di latar belakang."""
     journal = crud.journal.get(db=db, id=id)
     if not journal:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Journal not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Journal not found"
+        )
     if journal.owner_id != current_user.id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
 
     updated_journal = crud.journal.update(db=db, db_obj=journal, obj_in=journal_in)
 
     background_tasks.add_task(
-        asyncio.run, crud.journal.process_and_update_sentiment(db=db, journal_id=updated_journal.id)
+        crud.journal.process_and_update_sentiment, journal_id=updated_journal.id
     )
 
     return updated_journal
 
+
 @router.delete("/{id}", response_model=schemas.Journal)
 def delete_journal(
-        *,
-        db: Session = Depends(deps.get_db),
-        id: int,
-        current_user: models.User = Depends(deps.get_current_user),
+    *,
+    db: Session = Depends(deps.get_db),
+    id: int,
+    current_user: models.User = Depends(deps.get_current_user),
 ) -> Any:
     """Menghapus sebuah entri jurnal."""
     journal = crud.journal.get(db=db, id=id)
     if not journal:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Journal not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Journal not found"
+        )
     if journal.owner_id != current_user.id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+        )
 
     deleted_journal = crud.journal.remove(db=db, id=id)
     return deleted_journal

--- a/backend/app/crud/crud_journal.py
+++ b/backend/app/crud/crud_journal.py
@@ -2,14 +2,18 @@
 
 from typing import List
 from sqlalchemy.orm import Session
+from app.db.session import SessionLocal
 from app.crud.base import CRUDBase
 from app.db.models.journal import JournalEntry
 from app.schemas.journal import JournalCreate, JournalUpdate
-from app.services.sentiment_analyzer import analyze_sentiment_with_ai # PENAMBAHAN IMPORT
+from app.services.sentiment_analyzer import (
+    analyze_sentiment_with_ai,
+)  # PENAMBAHAN IMPORT
+
 
 class CRUDJournal(CRUDBase[JournalEntry, JournalCreate, JournalUpdate]):
     def create_with_owner(
-            self, db: Session, *, obj_in: JournalCreate, owner_id: int
+        self, db: Session, *, obj_in: JournalCreate, owner_id: int
     ) -> JournalEntry:
         obj_in_data = obj_in.model_dump()
         db_obj = self.model(**obj_in_data, owner_id=owner_id)
@@ -19,7 +23,7 @@ class CRUDJournal(CRUDBase[JournalEntry, JournalCreate, JournalUpdate]):
         return db_obj
 
     def get_multi_by_owner(
-            self, db: Session, *, owner_id: int, skip: int = 0, limit: int = 100
+        self, db: Session, *, owner_id: int, skip: int = 0, limit: int = 100
     ) -> List[JournalEntry]:
         return (
             db.query(self.model)
@@ -31,20 +35,26 @@ class CRUDJournal(CRUDBase[JournalEntry, JournalCreate, JournalUpdate]):
         )
 
     # --- PENAMBAHAN BARU ---
-    async def process_and_update_sentiment(self, db: Session, *, journal_id: int):
+    async def process_and_update_sentiment(self, *, journal_id: int):
         """
-        Fungsi yang akan dijalankan di background.
-        Mengambil jurnal, menganalisis sentimennya, dan menyimpan hasilnya.
+        Fungsi yang dijalankan di background untuk mengambil jurnal,
+        menganalisis sentimennya, dan menyimpan hasilnya.
         """
-        db_obj = self.get(db=db, id=journal_id)
-        if db_obj:
-            analysis_result = await analyze_sentiment_with_ai(db_obj.content)
-            if analysis_result:
-                db_obj.sentiment_score = analysis_result.get("sentiment_score")
-                db_obj.key_emotions = analysis_result.get("key_emotions")
-                db.add(db_obj)
-                db.commit()
-                db.refresh(db_obj)
+        db = SessionLocal()
+        try:
+            db_obj = self.get(db=db, id=journal_id)
+            if db_obj:
+                analysis_result = await analyze_sentiment_with_ai(db_obj.content)
+                if analysis_result:
+                    db_obj.sentiment_score = analysis_result.get("sentiment_score")
+                    db_obj.key_emotions = analysis_result.get("key_emotions")
+                    db.add(db_obj)
+                    db.commit()
+                    db.refresh(db_obj)
+        finally:
+            db.close()
+
     # --- AKHIR PENAMBAHAN ---
+
 
 journal = CRUDJournal(JournalEntry)


### PR DESCRIPTION
## Summary
- fix background task call signatures
- ensure `process_and_update_sentiment` creates its own DB session
- clean up unused imports

## Testing
- `python3 -m pip install -r backend/requirements.txt`
- `python3 -m pip install black`
- `black backend/app/api/v1/endpoints/journal.py backend/app/crud/crud_journal.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852236414c48324ae7849ddd3e6f68a