### PR TITLE
Add persistent chat storage

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
@@ -1,5 +1,21 @@
 package com.psy.deardiary.data.dto
 
+import com.google.gson.annotations.SerializedName
+
 data class ChatRequest(val message: String)
 
 data class ChatResponse(val reply: String)
+
+data class ChatMessageResponse(
+    val id: Int,
+    val text: String,
+    val isUser: Boolean,
+    val timestamp: Long,
+    @SerializedName("owner_id") val ownerId: Int
+)
+
+data class ChatMessageCreateRequest(
+    val text: String,
+    val isUser: Boolean,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatMappers.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatMappers.kt
@@ -1,0 +1,21 @@
+package com.psy.deardiary.data.dto
+
+import com.psy.deardiary.data.model.ChatMessage
+
+fun ChatMessageResponse.toChatMessage(): ChatMessage {
+    return ChatMessage(
+        remoteId = this.id,
+        text = this.text,
+        isUser = this.isUser,
+        timestamp = this.timestamp,
+        isSynced = true
+    )
+}
+
+fun ChatMessage.toCreateRequest(): ChatMessageCreateRequest {
+    return ChatMessageCreateRequest(
+        text = this.text,
+        isUser = this.isUser,
+        timestamp = this.timestamp
+    )
+}

--- a/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
@@ -6,10 +6,16 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.psy.deardiary.data.model.JournalEntry
+import com.psy.deardiary.data.model.ChatMessage
 
-// --- PERBAIKAN: Naikkan versi database dari 1 menjadi 2 ---
-@Database(entities = [JournalEntry::class], version = 2, exportSchema = false)
+// --- PERBAIKAN: Naikkan versi database dari 2 menjadi 3 ---
+@Database(
+    entities = [JournalEntry::class, ChatMessage::class],
+    version = 3,
+    exportSchema = false
+)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun journalDao(): JournalDao
+    abstract fun chatMessageDao(): ChatMessageDao
 }

--- a/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
@@ -1,0 +1,41 @@
+package com.psy.deardiary.data.local
+
+import androidx.room.*
+import com.psy.deardiary.data.model.ChatMessage
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ChatMessageDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMessage(message: ChatMessage): Long
+
+    @Query("SELECT * FROM chat_messages ORDER BY timestamp ASC")
+    fun getAllMessages(): Flow<List<ChatMessage>>
+
+    @Query("SELECT * FROM chat_messages WHERE isSynced = 0")
+    suspend fun getUnsyncedMessages(): List<ChatMessage>
+
+    @Query("UPDATE chat_messages SET remoteId = :remoteId, isSynced = 1 WHERE id = :id")
+    suspend fun markAsSynced(id: Int, remoteId: Int)
+
+    @Update
+    suspend fun updateMessage(message: ChatMessage)
+
+    @Query("SELECT * FROM chat_messages WHERE id = :id LIMIT 1")
+    suspend fun getMessageById(id: Int): ChatMessage?
+
+    @Query("DELETE FROM chat_messages")
+    suspend fun deleteAllMessages()
+
+    @Transaction
+    suspend fun upsertAll(messages: List<ChatMessage>) {
+        messages.forEach { message ->
+            val existing = getMessageById(message.id)
+            if (existing == null) {
+                insertMessage(message)
+            } else {
+                updateMessage(message.copy(id = existing.id))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
@@ -1,8 +1,16 @@
 package com.psy.deardiary.data.model
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "chat_messages")
 data class ChatMessage(
-    val id: Int,
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val remoteId: Int? = null,
     val text: String,
     val isUser: Boolean,
+    val timestamp: Long = System.currentTimeMillis(),
+    val isSynced: Boolean = false,
     val isPlaceholder: Boolean = false
 )

--- a/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
@@ -2,11 +2,20 @@ package com.psy.deardiary.data.network
 
 import com.psy.deardiary.data.dto.ChatRequest
 import com.psy.deardiary.data.dto.ChatResponse
+import com.psy.deardiary.data.dto.ChatMessageCreateRequest
+import com.psy.deardiary.data.dto.ChatMessageResponse
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
+import retrofit2.http.GET
 
 interface ChatApiService {
     @POST("api/v1/chat")
     suspend fun sendMessage(@Body request: ChatRequest): Response<ChatResponse>
+
+    @GET("api/v1/chat/messages")
+    suspend fun getMessages(): Response<List<ChatMessageResponse>>
+
+    @POST("api/v1/chat/messages")
+    suspend fun postMessage(@Body request: ChatMessageCreateRequest): Response<ChatMessageResponse>
 }

--- a/app/src/main/java/com/psy/deardiary/di/AppModule.kt
+++ b/app/src/main/java/com/psy/deardiary/di/AppModule.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import com.psy.deardiary.data.datastore.UserPreferencesRepository
 import com.psy.deardiary.data.local.AppDatabase
 import com.psy.deardiary.data.local.JournalDao
+import com.psy.deardiary.data.local.ChatMessageDao
 import com.psy.deardiary.data.network.AuthApiService
 import com.psy.deardiary.data.network.AuthInterceptor
 import com.psy.deardiary.data.network.ChatApiService
@@ -44,6 +45,12 @@ object AppModule {
     @Singleton
     fun provideJournalDao(appDatabase: AppDatabase): JournalDao {
         return appDatabase.journalDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideChatMessageDao(appDatabase: AppDatabase): ChatMessageDao {
+        return appDatabase.chatMessageDao()
     }
 
     @Provides
@@ -117,7 +124,10 @@ object AppModule {
     }
     @Provides
     @Singleton
-    fun provideChatRepository(chatApiService: ChatApiService): ChatRepository {
-        return ChatRepository(chatApiService)
+    fun provideChatRepository(
+        chatApiService: ChatApiService,
+        chatMessageDao: ChatMessageDao
+    ): ChatRepository {
+        return ChatRepository(chatApiService, chatMessageDao)
     }
 }

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -3,3 +3,4 @@
 
 from .crud_user import user
 from .crud_journal import journal
+from .crud_chat import chat_message

--- a/backend/app/crud/crud_chat.py
+++ b/backend/app/crud/crud_chat.py
@@ -1,0 +1,26 @@
+from typing import List
+from sqlalchemy.orm import Session
+from app.crud.base import CRUDBase
+from app.db.models.chat import ChatMessage
+from app.schemas.chat_message import ChatMessageCreate, ChatMessageUpdate
+
+class CRUDChatMessage(CRUDBase[ChatMessage, ChatMessageCreate, ChatMessageUpdate]):
+    def create_with_owner(self, db: Session, *, obj_in: ChatMessageCreate, owner_id: int) -> ChatMessage:
+        obj_in_data = obj_in.model_dump()
+        db_obj = ChatMessage(**obj_in_data, owner_id=owner_id)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def get_multi_by_owner(self, db: Session, *, owner_id: int, skip: int = 0, limit: int = 100) -> List[ChatMessage]:
+        return (
+            db.query(self.model)
+            .filter(ChatMessage.owner_id == owner_id)
+            .order_by(self.model.timestamp.asc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+chat_message = CRUDChatMessage(ChatMessage)

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -4,3 +4,4 @@
 from .base_class import Base
 from .models.user import User
 from .models.journal import JournalEntry
+from .models.chat import ChatMessage

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -5,3 +5,4 @@
 from app.db.base_class import Base
 from app.db.models.user import User
 from app.db.models.journal import JournalEntry
+from app.db.models.chat import ChatMessage

--- a/backend/app/db/models/chat.py
+++ b/backend/app/db/models/chat.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, Text, Boolean, BigInteger, ForeignKey
+from sqlalchemy.orm import relationship
+from app.db.base_class import Base
+
+class ChatMessage(Base):
+    __tablename__ = "chatmessages"
+    id = Column(Integer, primary_key=True, index=True)
+    text = Column(Text)
+    is_user = Column(Boolean, default=True)
+    timestamp = Column(BigInteger, nullable=False, index=True)
+    owner_id = Column(Integer, ForeignKey("users.id"))
+
+    owner = relationship("User")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -4,3 +4,4 @@
 
 from app.db.models.user import User
 from app.db.models.journal import JournalEntry
+from app.db.models.chat import ChatMessage

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -4,4 +4,9 @@
 from .user import User, UserCreate, LoginRequest
 from .journal import Journal, JournalCreate, JournalUpdate
 from .chat import ChatRequest, ChatResponse
+from .chat_message import (
+    ChatMessage,
+    ChatMessageCreate,
+    ChatMessageUpdate,
+)
 from .token import Token, TokenData

--- a/backend/app/schemas/chat_message.py
+++ b/backend/app/schemas/chat_message.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+class ChatMessageBase(BaseModel):
+    text: str
+    is_user: bool
+    timestamp: int
+
+class ChatMessageCreate(ChatMessageBase):
+    pass
+
+class ChatMessageUpdate(ChatMessageBase):
+    pass
+
+class ChatMessage(ChatMessageBase):
+    id: int
+    owner_id: int
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary
- support chat history on the backend via `ChatMessage` model and new endpoints
- expose chat message CRUD and schemas
- persist chat logs locally on Android with Room
- sync chat messages through `ChatRepository`
- load conversation history in `HomeChatViewModel`

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68523691b0748324b295a11dad69b4b6