### PR TITLE
Add backend CRUD and API tests

### DIFF
--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.db import Base
+from app.api import deps
+from app import crud
+from backend.main import app
+
+
+@pytest.fixture
+def client():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[deps.get_db] = override_get_db
+
+    async def noop(*args, **kwargs):
+        return None
+
+    crud.journal.process_and_update_sentiment = noop
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def register_and_login(client, email="user@example.com", password="pass"):
+    reg = client.post("/api/v1/users/register", json={"email": email, "password": password})
+    assert reg.status_code == 200
+    login = client.post("/api/v1/users/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_user_registration_login_delete(client):
+    headers = register_and_login(client)
+    resp = client.delete("/api/v1/users/me", headers=headers)
+    assert resp.status_code == 200
+
+
+def test_journal_crud_endpoints(client):
+    headers = register_and_login(client)
+
+    create_resp = client.post(
+        "/api/v1/journal/",
+        json={"title": "t", "content": "c", "mood": "ok", "timestamp": 1},
+        headers=headers,
+    )
+    assert create_resp.status_code == 201
+    journal_id = create_resp.json()["id"]
+
+    list_resp = client.get("/api/v1/journal/", headers=headers)
+    assert list_resp.status_code == 200
+    assert len(list_resp.json()) == 1
+
+    update_resp = client.put(
+        f"/api/v1/journal/{journal_id}",
+        json={"title": "t2", "content": "c2", "mood": "bad", "timestamp": 2},
+        headers=headers,
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.json()["title"] == "t2"
+
+    delete_resp = client.delete(f"/api/v1/journal/{journal_id}", headers=headers)
+    assert delete_resp.status_code == 200

--- a/backend/tests/test_crud_chat.py
+++ b/backend/tests/test_crud_chat.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from app.db import Base
 from app.db.models.chat import ChatMessage
+from app.schemas.chat_message import ChatMessageCreate
 from app.crud.crud_chat import chat_message
 
 
@@ -36,5 +37,17 @@ def test_get_last_user_messages(db_session):
 
     results = chat_message.get_last_user_messages(db_session, owner_id=1, limit=2)
     assert [m.text for m in results] == ["u3", "u2"]
+
+
+def test_chat_message_crud(db_session):
+    msg_in = ChatMessageCreate(text="hi", is_user=True, timestamp=1)
+    created = chat_message.create_with_owner(db_session, obj_in=msg_in, owner_id=1)
+    assert created.id is not None
+
+    updated = chat_message.update(db_session, db_obj=created, obj_in={"text": "bye"})
+    assert updated.text == "bye"
+
+    chat_message.remove(db_session, id=created.id)
+    assert chat_message.get(db_session, id=created.id) is None
 
 

--- a/backend/tests/test_crud_journal.py
+++ b/backend/tests/test_crud_journal.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.db import Base
+from app.schemas.user import UserCreate
+from app.schemas.journal import JournalCreate, JournalUpdate
+from app.crud.crud_user import user
+from app.crud.crud_journal import journal
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_journal_crud_flow(db_session):
+    owner = user.create(db_session, obj_in=UserCreate(email="user@example.com", password="pass"))
+
+    entry = journal.create_with_owner(
+        db_session,
+        obj_in=JournalCreate(title="t", content="c", mood="happy", timestamp=1),
+        owner_id=owner.id,
+    )
+    assert entry.id is not None
+    assert entry.owner_id == owner.id
+
+    all_journals = journal.get_multi_by_owner(db_session, owner_id=owner.id)
+    assert len(all_journals) == 1
+
+    updated = journal.update(db_session, db_obj=entry, obj_in=JournalUpdate(title="t2", content="c2", mood="sad", timestamp=2))
+    assert updated.title == "t2"
+
+    journal.remove(db_session, id=entry.id)
+    assert journal.get(db_session, id=entry.id) is None

--- a/backend/tests/test_crud_user.py
+++ b/backend/tests/test_crud_user.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.db import Base
+from app.schemas.user import UserCreate
+from app.crud.crud_user import user
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_user_crud_flow(db_session):
+    # create
+    new_user = user.create(db_session, obj_in=UserCreate(email="a@b.com", password="pass"))
+    assert new_user.id is not None
+    assert new_user.email == "a@b.com"
+    assert new_user.hashed_password != "pass"
+
+    # update
+    updated = user.update(db_session, db_obj=new_user, obj_in={"is_active": False})
+    assert updated.is_active is False
+
+    # get by email
+    got = user.get_by_email(db_session, email="a@b.com")
+    assert got.id == new_user.id
+
+    # remove
+    user.remove(db_session, id=new_user.id)
+    assert user.get(db_session, id=new_user.id) is None


### PR DESCRIPTION
## Summary
- add CRUD unit tests for user, journal and chat message models
- add FastAPI endpoint tests using TestClient and dependency overrides
- extend chat CRUD tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685256cb4a2483249897bc543f7fb583