### PR TITLE
Implement dynamic home feed

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/FeedDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/FeedDtos.kt
@@ -1,0 +1,16 @@
+package com.psy.deardiary.data.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class ArticleResponse(
+    val title: String,
+    val source: String,
+    @SerializedName("image_url") val imageUrl: String
+)
+
+data class FeedItemResponse(
+    val type: String,
+    val journal: JournalResponse?,
+    val article: ArticleResponse?,
+    val message: String?
+)

--- a/app/src/main/java/com/psy/deardiary/data/dto/FeedMappers.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/FeedMappers.kt
@@ -1,0 +1,18 @@
+package com.psy.deardiary.data.dto
+
+import com.psy.deardiary.features.home.FeedItem
+import com.psy.deardiary.features.media.Article
+import com.psy.deardiary.data.dto.toJournalEntry
+
+fun ArticleResponse.toArticle(): Article {
+    return Article(title = title, source = source, imageUrl = imageUrl)
+}
+
+fun FeedItemResponse.toFeedItem(): FeedItem? {
+    return when (type) {
+        "journal" -> journal?.toJournalEntry()?.let { FeedItem.JournalItem(it) }
+        "article_suggestion" -> article?.toArticle()?.let { FeedItem.ArticleSuggestionItem(it) }
+        "chat_prompt" -> message?.let { FeedItem.ChatPromptItem(it) }
+        else -> null
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/data/network/FeedApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/FeedApiService.kt
@@ -1,0 +1,10 @@
+package com.psy.deardiary.data.network
+
+import com.psy.deardiary.data.dto.FeedItemResponse
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface FeedApiService {
+    @GET("api/v1/feed")
+    suspend fun getFeed(): Response<List<FeedItemResponse>>
+}

--- a/app/src/main/java/com/psy/deardiary/data/repository/FeedRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/FeedRepository.kt
@@ -1,0 +1,35 @@
+package com.psy.deardiary.data.repository
+
+import com.psy.deardiary.data.dto.FeedItemResponse
+import com.psy.deardiary.data.dto.toFeedItem
+import com.psy.deardiary.data.network.FeedApiService
+import com.psy.deardiary.features.home.FeedItem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FeedRepository @Inject constructor(
+    private val feedApiService: FeedApiService
+) {
+    suspend fun getFeed(): Result<List<FeedItem>> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = feedApiService.getFeed()
+                if (response.isSuccessful && response.body() != null) {
+                    val items = response.body()!!.mapNotNull { it.toFeedItem() }
+                    Result.Success(items)
+                } else {
+                    Result.Error("${'$'}{response.message()}")
+                }
+            } catch (e: HttpException) {
+                Result.Error("Server error: ${'$'}{e.code()}")
+            } catch (e: IOException) {
+                Result.Error("Tidak dapat terhubung ke server.")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/di/AppModule.kt
+++ b/app/src/main/java/com/psy/deardiary/di/AppModule.kt
@@ -10,9 +10,11 @@ import com.psy.deardiary.data.network.AuthApiService
 import com.psy.deardiary.data.network.AuthInterceptor
 import com.psy.deardiary.data.network.ChatApiService
 import com.psy.deardiary.data.network.JournalApiService
+import com.psy.deardiary.data.network.FeedApiService
 import com.psy.deardiary.data.repository.AuthRepository
 import com.psy.deardiary.data.repository.ChatRepository
 import com.psy.deardiary.data.repository.JournalRepository
+import com.psy.deardiary.data.repository.FeedRepository
 import com.psy.deardiary.BuildConfig
 import dagger.Module
 import dagger.Provides
@@ -107,6 +109,12 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideFeedApiService(retrofit: Retrofit): FeedApiService {
+        return retrofit.create(FeedApiService::class.java)
+    }
+
+    @Provides
+    @Singleton
     fun provideAuthRepository(
         authApiService: AuthApiService,
         userPreferencesRepository: UserPreferencesRepository
@@ -129,5 +137,13 @@ object AppModule {
         chatMessageDao: ChatMessageDao
     ): ChatRepository {
         return ChatRepository(chatApiService, chatMessageDao)
+    }
+
+    @Provides
+    @Singleton
+    fun provideFeedRepository(
+        feedApiService: FeedApiService
+    ): FeedRepository {
+        return FeedRepository(feedApiService)
     }
 }

--- a/app/src/main/java/com/psy/deardiary/features/home/FeedItem.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/FeedItem.kt
@@ -6,4 +6,5 @@ import com.psy.deardiary.features.media.Article
 sealed interface FeedItem {
     data class JournalItem(val journalEntry: JournalEntry) : FeedItem
     data class ArticleSuggestionItem(val article: Article) : FeedItem
+    data class ChatPromptItem(val message: String) : FeedItem
 }

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -84,6 +84,7 @@ fun HomeScreen(
                             when (item) {
                                 is FeedItem.JournalItem -> JournalItemCard(item.journalEntry)
                                 is FeedItem.ArticleSuggestionItem -> ArticleSuggestionCard(item.article)
+                                is FeedItem.ChatPromptItem -> ChatPromptCard(item.message)
                             }
                         }
                         items(messages, key = { it.id }) { msg ->

--- a/app/src/main/java/com/psy/deardiary/features/home/components/FeedCards.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/components/FeedCards.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.SentimentNeutral
+import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -158,6 +159,33 @@ fun ArticleSuggestionCard(article: Article, modifier: Modifier = Modifier) {
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+            }
+        }
+    }
+}
+
+@Composable
+fun ChatPromptCard(message: String, modifier: Modifier = Modifier) {
+    AnimatedVisibility(
+        visible = true,
+        enter = fadeIn() + scaleIn(),
+        exit = fadeOut()
+    ) {
+        OutlinedCard(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        ) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.ChatBubbleOutline,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 12.dp)
+                )
+                Text(message)
             }
         }
     }

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeViewModelTest.kt
@@ -1,10 +1,9 @@
-import com.psy.deardiary.data.model.JournalEntry
-import com.psy.deardiary.data.repository.JournalRepository
+import com.psy.deardiary.data.repository.FeedRepository
+import com.psy.deardiary.data.repository.Result
 import com.psy.deardiary.features.home.FeedItem
 import com.psy.deardiary.features.home.HomeViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -20,16 +19,15 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
-    private val journalFlow = MutableStateFlow<List<JournalEntry>>(emptyList())
-    private lateinit var repository: JournalRepository
+    private lateinit var repository: FeedRepository
     private lateinit var viewModel: HomeViewModel
 
     @Before
     fun setup() {
         Dispatchers.setMain(dispatcher)
         repository = mock()
-        whenever(repository.journals).thenReturn(journalFlow)
-        viewModel = HomeViewModel(repository)
+        whenever(repository.getFeed()).thenReturn(Result.Success(emptyList()))
+        viewModel = HomeViewModel(mock(), repository)
     }
 
     @After
@@ -39,12 +37,12 @@ class HomeViewModelTest {
 
     @Test
     fun feedUpdates_whenEntriesEmitted() = runTest {
-        val entry = JournalEntry(title = "t", content = "saya cemas", mood = "😟", tags = emptyList())
-        journalFlow.value = listOf(entry)
+        whenever(repository.getFeed()).thenReturn(
+            Result.Success(listOf(FeedItem.ChatPromptItem("hi")))
+        )
         advanceUntilIdle()
         val feed = viewModel.uiState.value.feedItems
-        assertEquals(2, feed.size)
-        assertTrue(feed[0] is FeedItem.JournalItem)
-        assertTrue(feed[1] is FeedItem.ArticleSuggestionItem)
+        assertEquals(1, feed.size)
+        assertTrue(feed[0] is FeedItem.ChatPromptItem)
     }
 }

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -3,9 +3,10 @@
 
 from fastapi import APIRouter
 from app.api.v1.endpoints import auth, journal
-from app.api.v1.endpoints import chat
+from app.api.v1.endpoints import chat, feed
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/users", tags=["auth"])
 api_router.include_router(journal.router, prefix="/journal", tags=["journal"])
 api_router.include_router(chat.router, prefix="/chat", tags=["chat"])
+api_router.include_router(feed.router, prefix="/feed", tags=["feed"])

--- a/backend/app/api/v1/endpoints/feed.py
+++ b/backend/app/api/v1/endpoints/feed.py
@@ -1,0 +1,60 @@
+from typing import List
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app import crud, models, schemas
+from app.api import deps
+
+router = APIRouter()
+
+@router.get("/", response_model=List[schemas.FeedItem])
+def read_feed(
+    *,
+    db: Session = Depends(deps.get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    """Generate a simple personalized feed."""
+    journals = crud.journal.get_multi_by_owner(db, owner_id=current_user.id, limit=5)
+    items: List[schemas.FeedItem] = [
+        schemas.FeedItem(type="journal", journal=j) for j in journals
+    ]
+
+    last_journal = journals[0] if journals else None
+    if last_journal and (last_journal.sentiment_score or 0) < 0:
+        items.append(
+            schemas.FeedItem(
+                type="article_suggestion",
+                article=schemas.Article(
+                    title="Mengelola Pikiran Negatif",
+                    source="Psikologi+",
+                    image_url="https://placehold.co/600x400/D3E4F7/001D35?text=Artikel",
+                ),
+            )
+        )
+
+    last_msg = crud.chat_message.get_last_user_messages(db, owner_id=current_user.id, limit=1)
+    now_ms = int(datetime.utcnow().timestamp() * 1000)
+    if not last_msg or now_ms - last_msg[0].timestamp > 86_400_000:
+        items.append(
+            schemas.FeedItem(
+                type="chat_prompt",
+                message="Coba ngobrol dengan Dear Diary Chat hari ini!",
+            )
+        )
+
+    hour = datetime.now().hour
+    if hour >= 22 or hour < 6:
+        items.append(
+            schemas.FeedItem(
+                type="article_suggestion",
+                article=schemas.Article(
+                    title="Meditasi sebelum Tidur",
+                    source="HelloSehat",
+                    image_url="https://placehold.co/600x400/D3E4F7/001D35?text=Artikel",
+                ),
+            )
+        )
+
+    return items

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -10,3 +10,4 @@ from .chat_message import (
     ChatMessageUpdate,
 )
 from .token import Token, TokenData
+from .feed import FeedItem, Article

--- a/backend/app/schemas/feed.py
+++ b/backend/app/schemas/feed.py
@@ -1,0 +1,15 @@
+from typing import Optional
+from pydantic import BaseModel
+
+from .journal import Journal
+
+class Article(BaseModel):
+    title: str
+    source: str
+    image_url: str
+
+class FeedItem(BaseModel):
+    type: str
+    journal: Optional[Journal] = None
+    article: Optional[Article] = None
+    message: Optional[str] = None

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -84,3 +84,10 @@ def test_journal_crud_endpoints(client):
 
     delete_resp = client.delete(f"/api/v1/journal/{journal_id}", headers=headers)
     assert delete_resp.status_code == 200
+
+
+def test_feed_endpoint(client):
+    headers = register_and_login(client, email="feed@example.com")
+    resp = client.get("/api/v1/feed", headers=headers)
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)


### PR DESCRIPTION
## Summary
- support dynamic feed items from backend
- create backend `/api/v1/feed` endpoint and schema
- add Kotlin DTOs, repository and API service for feed
- render new chat prompt card

## Testing
- `pytest -q` *(fails: ImportError for pydantic/fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685279d2acf8832490c80dc2dcd2f2fe