### PR TITLE
Update default DB path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Backend menggunakan FastAPI dan SQLAlchemy. Skema database dikelola melalui Alem
    pip install -r backend/requirements.txt
    ```
 
-2. Jalankan migrasi database:
+2. Jalankan migrasi database (secara default database SQLite akan dibuat di `backend/test.db`):
 
    ```bash
    alembic -c backend/alembic.ini upgrade head

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -7,7 +7,7 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Dear Diary API"
     API_V1_STR: str = "/api/v1"
 
-    DATABASE_URL: str = os.getenv("DATABASE_URL", "sqlite:///./test.db")
+    DATABASE_URL: str = os.getenv("DATABASE_URL", "sqlite:///backend/test.db")
 
     # Isi nilainya melalui environment variable
     SECRET_KEY: str = os.getenv("SECRET_KEY", "CHANGE_ME")


### PR DESCRIPTION
## Summary
- move SQLite db to `backend/test.db`
- note path for migrations in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852966a1eec83248e5040f17c50404e