### PR TITLE
Clarify Alembic execution location

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Backend menggunakan FastAPI dan SQLAlchemy. Skema database dikelola melalui Alem
    pip install -r backend/requirements.txt
    ```
 
-2. Jalankan migrasi database (secara default database SQLite akan dibuat di `backend/test.db`):
+2. Dari direktori *root* repository, jalankan migrasi database (secara default
+   database SQLite akan dibuat di `backend/test.db`):
 
    ```bash
    alembic -c backend/alembic.ini upgrade head
@@ -105,7 +106,9 @@ Backend menggunakan FastAPI dan SQLAlchemy. Skema database dikelola melalui Alem
 
 ### Troubleshooting
 
-Jika saat menjalankan backend Anda melihat pesan `sqlite3.OperationalError: no such table: users`, jalankan migrasi dari direktori root untuk membuat `backend/test.db`:
+Jika saat menjalankan backend Anda melihat pesan `sqlite3.OperationalError: no such table: users`,
+pastikan perintah migrasi dijalankan dari direktori *root* sehingga file
+`backend/test.db` dibuat pada lokasi yang benar:
 
 ```bash
 alembic -c backend/alembic.ini upgrade head


### PR DESCRIPTION
## Summary
- add explicit instruction to run Alembic from the repo root
- expand troubleshooting note with same emphasis

## Testing
- `pip install -r backend/requirements.txt pytest`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852aac4c2188324a5efa0006fad6363