### PR TITLE
Support multiple users with userId column

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/datastore/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/datastore/UserPreferencesRepository.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -25,6 +26,7 @@ class UserPreferencesRepository @Inject constructor(@ApplicationContext context:
         val AUTH_TOKEN = stringPreferencesKey("auth_token")
         // PENAMBAHAN BARU: Key untuk menyimpan nomor kontak darurat
         val EMERGENCY_CONTACT = stringPreferencesKey("emergency_contact_number")
+        val USER_ID = intPreferencesKey("user_id")
     }
 
     val authToken: Flow<String?> = dataStore.data.map { preferences ->
@@ -36,9 +38,19 @@ class UserPreferencesRepository @Inject constructor(@ApplicationContext context:
         preferences[PreferencesKeys.EMERGENCY_CONTACT]
     }
 
+    val userId: Flow<Int?> = dataStore.data.map { preferences ->
+        preferences[PreferencesKeys.USER_ID]
+    }
+
     suspend fun saveAuthToken(token: String) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.AUTH_TOKEN] = token
+        }
+    }
+
+    suspend fun saveUserId(id: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.USER_ID] = id
         }
     }
 
@@ -52,6 +64,12 @@ class UserPreferencesRepository @Inject constructor(@ApplicationContext context:
     suspend fun clearAuthToken() {
         dataStore.edit { preferences ->
             preferences.remove(PreferencesKeys.AUTH_TOKEN)
+        }
+    }
+
+    suspend fun clearUserId() {
+        dataStore.edit { preferences ->
+            preferences.remove(PreferencesKeys.USER_ID)
         }
     }
 }

--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatMappers.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatMappers.kt
@@ -5,6 +5,7 @@ import com.psy.deardiary.data.model.ChatMessage
 fun ChatMessageResponse.toChatMessage(): ChatMessage {
     return ChatMessage(
         remoteId = this.id,
+        userId = this.ownerId,
         text = this.text,
         isUser = this.isUser,
         timestamp = this.timestamp,

--- a/app/src/main/java/com/psy/deardiary/data/dto/JournalMappers.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/JournalMappers.kt
@@ -7,6 +7,7 @@ import com.psy.deardiary.data.model.JournalEntry
 fun JournalResponse.toJournalEntry(): JournalEntry {
     return JournalEntry(
         remoteId = this.id,
+        userId = this.ownerId,
         title = this.title ?: "",
         content = this.content,
         mood = this.mood,

--- a/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
@@ -5,17 +5,28 @@ package com.psy.deardiary.data.local
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.psy.deardiary.data.model.JournalEntry
 import com.psy.deardiary.data.model.ChatMessage
 
 // --- PERBAIKAN: Naikkan versi database dari 2 menjadi 3 ---
 @Database(
     entities = [JournalEntry::class, ChatMessage::class],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun journalDao(): JournalDao
     abstract fun chatMessageDao(): ChatMessageDao
+
+    companion object {
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE chat_messages ADD COLUMN userId INTEGER NOT NULL DEFAULT 0")
+                database.execSQL("ALTER TABLE journal_entries ADD COLUMN userId INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
@@ -8,6 +8,7 @@ data class ChatMessage(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
     val remoteId: Int? = null,
+    val userId: Int = 0,
     val text: String,
     val isUser: Boolean,
     val timestamp: Long = System.currentTimeMillis(),

--- a/app/src/main/java/com/psy/deardiary/data/model/JournalEntry.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/JournalEntry.kt
@@ -10,6 +10,7 @@ data class JournalEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
     val remoteId: Int? = null,
+    val userId: Int = 0,
     val title: String,
     val content: String,
     val mood: String,

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -5,7 +5,11 @@ import com.psy.deardiary.data.dto.toCreateRequest
 import com.psy.deardiary.data.dto.toChatMessage
 import com.psy.deardiary.data.model.ChatMessage
 import com.psy.deardiary.data.local.ChatMessageDao
+import com.psy.deardiary.data.datastore.UserPreferencesRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.first
 import com.psy.deardiary.data.network.ChatApiService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -18,9 +22,13 @@ import com.psy.deardiary.data.repository.Result
 @Singleton
 class ChatRepository @Inject constructor(
     private val chatApiService: ChatApiService,
-    private val chatMessageDao: ChatMessageDao
+    private val chatMessageDao: ChatMessageDao,
+    private val userPreferencesRepository: UserPreferencesRepository
 ) {
-    val messages: Flow<List<ChatMessage>> = chatMessageDao.getAllMessages()
+    val messages: Flow<List<ChatMessage>> =
+        userPreferencesRepository.userId.flatMapLatest { id ->
+            id?.let { chatMessageDao.getAllMessages(it) } ?: flowOf(emptyList())
+        }
 
     fun getConversation(): Flow<List<ChatMessage>> = messages
 
@@ -29,8 +37,9 @@ class ChatRepository @Inject constructor(
             try {
                 val response = chatApiService.getMessages()
                 if (response.isSuccessful && response.body() != null) {
+                    val uid = userPreferencesRepository.userId.first() ?: return@withContext Result.Error("User not logged in")
                     val messages = response.body()!!.map { it.toChatMessage() }
-                    chatMessageDao.upsertAll(messages)
+                    chatMessageDao.upsertAll(messages.map { it.copy(userId = uid) })
                     Result.Success(Unit)
                 } else {
                     Result.Error("${'$'}{response.message()}")
@@ -42,18 +51,21 @@ class ChatRepository @Inject constructor(
     }
 
     suspend fun addMessage(text: String, isUser: Boolean, isPlaceholder: Boolean = false): ChatMessage {
+        val uid = userPreferencesRepository.userId.first() ?: 0
         val message = ChatMessage(
             text = text,
             isUser = isUser,
             isPlaceholder = isPlaceholder,
-            isSynced = false
+            isSynced = false,
+            userId = uid
         )
         val id = chatMessageDao.insertMessage(message).toInt()
         return message.copy(id = id)
     }
 
     suspend fun replaceMessage(id: Int, newText: String) {
-        val existing = chatMessageDao.getMessageById(id) ?: return
+        val uid = userPreferencesRepository.userId.first() ?: return
+        val existing = chatMessageDao.getMessageById(id, uid) ?: return
         val updated = existing.copy(text = newText, isPlaceholder = false)
         chatMessageDao.updateMessage(updated)
     }
@@ -79,7 +91,8 @@ class ChatRepository @Inject constructor(
     suspend fun syncPendingMessages(): Result<Unit> {
         return withContext(Dispatchers.IO) {
             try {
-                val unsynced = chatMessageDao.getUnsyncedMessages()
+                val uid = userPreferencesRepository.userId.first() ?: return@withContext Result.Error("User not logged in")
+                val unsynced = chatMessageDao.getUnsyncedMessages(uid)
                 for (msg in unsynced) {
                     val response = chatApiService.postMessage(msg.toCreateRequest())
                     if (response.isSuccessful && response.body() != null) {

--- a/app/src/main/java/com/psy/deardiary/di/AppModule.kt
+++ b/app/src/main/java/com/psy/deardiary/di/AppModule.kt
@@ -39,7 +39,7 @@ object AppModule {
             AppDatabase::class.java,
             "dear_diary_database"
         )
-            .fallbackToDestructiveMigration()
+            .addMigrations(AppDatabase.MIGRATION_3_4)
             .build()
     }
 
@@ -126,17 +126,19 @@ object AppModule {
     @Singleton
     fun provideJournalRepository(
         journalApiService: JournalApiService,
-        journalDao: JournalDao
+        journalDao: JournalDao,
+        userPreferencesRepository: UserPreferencesRepository
     ): JournalRepository {
-        return JournalRepository(journalApiService, journalDao)
+        return JournalRepository(journalApiService, journalDao, userPreferencesRepository)
     }
     @Provides
     @Singleton
     fun provideChatRepository(
         chatApiService: ChatApiService,
-        chatMessageDao: ChatMessageDao
+        chatMessageDao: ChatMessageDao,
+        userPreferencesRepository: UserPreferencesRepository
     ): ChatRepository {
-        return ChatRepository(chatApiService, chatMessageDao)
+        return ChatRepository(chatApiService, chatMessageDao, userPreferencesRepository)
     }
 
     @Provides

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
@@ -39,8 +39,8 @@ class HomeChatViewModelTest {
 
     @Test
     fun sendMessage_delegatesToRepository() = runTest {
-        whenever(repository.addMessage(any(), eq(true), eq(false))).thenReturn(ChatMessage(text="hi", isUser=true))
-        whenever(repository.addMessage(any(), eq(false), eq(true))).thenReturn(ChatMessage(id=2, text="placeholder", isUser=false, isPlaceholder=true))
+        whenever(repository.addMessage(any(), eq(true), eq(false))).thenReturn(ChatMessage(text="hi", isUser=true, userId = 1))
+        whenever(repository.addMessage(any(), eq(false), eq(true))).thenReturn(ChatMessage(id=2, text="placeholder", isUser=false, isPlaceholder=true, userId = 1))
         whenever(repository.fetchReply("hi")).thenReturn(Result.Success("hello"))
         viewModel.sendMessage("hi")
         advanceUntilIdle()


### PR DESCRIPTION
## Summary
- add `userId` column to `ChatMessage` and `JournalEntry`
- store `userId` in `UserPreferencesRepository`
- read/write user data in DAOs, repositories and migration
- wire repositories with `UserPreferencesRepository`

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6852c425a4b88324bf68a532732efd96