### PR TITLE
Implement user profile features

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/UserDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/UserDtos.kt
@@ -1,0 +1,20 @@
+package com.psy.deardiary.data.dto
+
+import com.google.gson.annotations.SerializedName
+import com.psy.deardiary.data.model.UserProfile
+
+data class UserProfileResponse(
+    val id: Int,
+    val email: String,
+    val name: String?,
+    val bio: String?
+)
+
+data class UserProfileUpdateRequest(
+    val name: String?,
+    val bio: String?
+)
+
+fun UserProfileResponse.toUserProfile(): UserProfile {
+    return UserProfile(id = id, email = email, name = name, bio = bio)
+}

--- a/app/src/main/java/com/psy/deardiary/data/model/UserProfile.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/UserProfile.kt
@@ -1,0 +1,8 @@
+package com.psy.deardiary.data.model
+
+data class UserProfile(
+    val id: Int,
+    val email: String,
+    val name: String?,
+    val bio: String?
+)

--- a/app/src/main/java/com/psy/deardiary/data/network/UserApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/UserApiService.kt
@@ -1,0 +1,16 @@
+package com.psy.deardiary.data.network
+
+import com.psy.deardiary.data.dto.UserProfileResponse
+import com.psy.deardiary.data.dto.UserProfileUpdateRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PUT
+
+interface UserApiService {
+    @GET("api/v1/users/me")
+    suspend fun getProfile(): Response<UserProfileResponse>
+
+    @PUT("api/v1/users/me")
+    suspend fun updateProfile(@Body body: UserProfileUpdateRequest): Response<UserProfileResponse>
+}

--- a/app/src/main/java/com/psy/deardiary/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/UserRepository.kt
@@ -1,0 +1,53 @@
+package com.psy.deardiary.data.repository
+
+import com.psy.deardiary.data.dto.UserProfileResponse
+import com.psy.deardiary.data.dto.UserProfileUpdateRequest
+import com.psy.deardiary.data.dto.toUserProfile
+import com.psy.deardiary.data.model.UserProfile
+import com.psy.deardiary.data.network.UserApiService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UserRepository @Inject constructor(
+    private val userApiService: UserApiService
+) {
+    suspend fun getProfile(): Result<UserProfile> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = userApiService.getProfile()
+                if (response.isSuccessful && response.body() != null) {
+                    Result.Success(response.body()!!.toUserProfile())
+                } else {
+                    Result.Error("${'$'}{response.message()}")
+                }
+            } catch (e: HttpException) {
+                Result.Error("Server error: ${'$'}{e.code()}")
+            } catch (e: IOException) {
+                Result.Error("Tidak dapat terhubung ke server.")
+            }
+        }
+    }
+
+    suspend fun updateProfile(name: String?, bio: String?): Result<UserProfile> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val body = UserProfileUpdateRequest(name, bio)
+                val response = userApiService.updateProfile(body)
+                if (response.isSuccessful && response.body() != null) {
+                    Result.Success(response.body()!!.toUserProfile())
+                } else {
+                    Result.Error("${'$'}{response.message()}")
+                }
+            } catch (e: HttpException) {
+                Result.Error("Server error: ${'$'}{e.code()}")
+            } catch (e: IOException) {
+                Result.Error("Tidak dapat terhubung ke server.")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/di/AppModule.kt
+++ b/app/src/main/java/com/psy/deardiary/di/AppModule.kt
@@ -11,10 +11,12 @@ import com.psy.deardiary.data.network.AuthInterceptor
 import com.psy.deardiary.data.network.ChatApiService
 import com.psy.deardiary.data.network.JournalApiService
 import com.psy.deardiary.data.network.FeedApiService
+import com.psy.deardiary.data.network.UserApiService
 import com.psy.deardiary.data.repository.AuthRepository
 import com.psy.deardiary.data.repository.ChatRepository
 import com.psy.deardiary.data.repository.JournalRepository
 import com.psy.deardiary.data.repository.FeedRepository
+import com.psy.deardiary.data.repository.UserRepository
 import com.psy.deardiary.BuildConfig
 import dagger.Module
 import dagger.Provides
@@ -115,6 +117,12 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideUserApiService(retrofit: Retrofit): UserApiService {
+        return retrofit.create(UserApiService::class.java)
+    }
+
+    @Provides
+    @Singleton
     fun provideAuthRepository(
         authApiService: AuthApiService,
         userPreferencesRepository: UserPreferencesRepository
@@ -147,5 +155,13 @@ object AppModule {
         feedApiService: FeedApiService
     ): FeedRepository {
         return FeedRepository(feedApiService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideUserRepository(
+        userApiService: UserApiService
+    ): UserRepository {
+        return UserRepository(userApiService)
     }
 }

--- a/app/src/main/java/com/psy/deardiary/features/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/profile/ProfileScreen.kt
@@ -1,0 +1,75 @@
+package com.psy.deardiary.features.profile
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(
+    onBackClick: () -> Unit,
+    viewModel: ProfileViewModel = hiltViewModel()
+) {
+    val state by viewModel.uiState.collectAsState()
+    var name by remember { mutableStateOf("") }
+    var bio by remember { mutableStateOf("") }
+
+    LaunchedEffect(state.name) { name = state.name }
+    LaunchedEffect(state.bio) { bio = state.bio }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Profil") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Kembali")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (state.isLoading) {
+            Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(text = state.email, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Bold)
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Nama") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = bio,
+                    onValueChange = { bio = it },
+                    label = { Text("Bio") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Button(onClick = { viewModel.updateProfile(name, bio) }) {
+                    Text("Simpan")
+                }
+                state.message?.let { msg ->
+                    LaunchedEffect(msg) {
+                        viewModel.onMessageShown()
+                    }
+                    Text(text = msg, color = MaterialTheme.colorScheme.primary)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/features/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/profile/ProfileViewModel.kt
@@ -1,0 +1,66 @@
+package com.psy.deardiary.features.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.psy.deardiary.data.model.UserProfile
+import com.psy.deardiary.data.repository.Result
+import com.psy.deardiary.data.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class ProfileUiState(
+    val isLoading: Boolean = true,
+    val email: String = "",
+    val name: String = "",
+    val bio: String = "",
+    val message: String? = null
+)
+
+@HiltViewModel
+class ProfileViewModel @Inject constructor(
+    private val userRepository: UserRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ProfileUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init { loadProfile() }
+
+    fun loadProfile() {
+        viewModelScope.launch {
+            when (val result = userRepository.getProfile()) {
+                is Result.Success -> applyProfile(result.data)
+                is Result.Error -> _uiState.update { it.copy(isLoading = false, message = result.message) }
+            }
+        }
+    }
+
+    private fun applyProfile(profile: UserProfile) {
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                email = profile.email,
+                name = profile.name.orEmpty(),
+                bio = profile.bio.orEmpty()
+            )
+        }
+    }
+
+    fun updateProfile(name: String, bio: String) {
+        viewModelScope.launch {
+            when (val result = userRepository.updateProfile(name, bio)) {
+                is Result.Success -> {
+                    applyProfile(result.data)
+                    _uiState.update { it.copy(message = "Profil diperbarui") }
+                }
+                is Result.Error -> _uiState.update { it.copy(message = result.message) }
+            }
+        }
+    }
+
+    fun onMessageShown() { _uiState.update { it.copy(message = null) } }
+}

--- a/app/src/main/java/com/psy/deardiary/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/settings/SettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Policy
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -36,6 +37,7 @@ fun SettingsScreen(
     onNavigateToNotification: () -> Unit,
     onNavigateToPrivacyPolicy: () -> Unit,
     onNavigateToEmergencyContact: () -> Unit,
+    onNavigateToProfile: () -> Unit,
     onAccountDeleted: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
@@ -133,6 +135,17 @@ fun SettingsScreen(
 
             Divider(modifier = Modifier.padding(vertical = 16.dp))
 
+            Text("Akun", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingItem(
+                icon = Icons.Default.Person,
+                title = "Profil Saya",
+                description = "Lihat dan ubah informasi akun.",
+                onClick = onNavigateToProfile
+            )
+
+            Divider(modifier = Modifier.padding(vertical = 16.dp))
+
             Text("Aplikasi", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
             Spacer(modifier = Modifier.height(8.dp))
             SettingItem(
@@ -203,6 +216,7 @@ private fun SettingsScreenPreview() {
             onNavigateToNotification = {},
             onNavigateToPrivacyPolicy = {},
             onNavigateToEmergencyContact = {},
+            onNavigateToProfile = {},
             onAccountDeleted = {}
         )
     }

--- a/app/src/main/java/com/psy/deardiary/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/psy/deardiary/navigation/AppNavigation.kt
@@ -15,6 +15,7 @@ import com.psy.deardiary.features.services.dass.DassTestScreen
 import com.psy.deardiary.features.services.mbti.MbtiResultScreen
 import com.psy.deardiary.features.services.mbti.MbtiTestScreen
 import com.psy.deardiary.features.settings.*
+import com.psy.deardiary.features.profile.ProfileScreen
 
 @Composable
 fun AppNavigation(navController: NavHostController) {
@@ -156,6 +157,7 @@ fun AppNavigation(navController: NavHostController) {
                 onNavigateToNotification = { navController.navigate(Screen.NotificationSettings.route) },
                 onNavigateToPrivacyPolicy = { navController.navigate(Screen.PrivacyPolicy.route) },
                 onNavigateToEmergencyContact = { navController.navigate(Screen.EmergencyContactSettings.route) },
+                onNavigateToProfile = { navController.navigate(Screen.Profile.route) },
                 onAccountDeleted = {
                     navController.navigate(Screen.Onboarding.route) {
                         popUpTo(navController.graph.id) { inclusive = true }
@@ -174,6 +176,10 @@ fun AppNavigation(navController: NavHostController) {
 
         composable(Screen.EmergencyContactSettings.route) {
             EmergencyContactScreen(onBackClick = { navController.popBackStack() })
+        }
+
+        composable(Screen.Profile.route) {
+            ProfileScreen(onBackClick = { navController.popBackStack() })
         }
 
         // --- BANTUAN KRISIS ---

--- a/app/src/main/java/com/psy/deardiary/navigation/Screen.kt
+++ b/app/src/main/java/com/psy/deardiary/navigation/Screen.kt
@@ -19,6 +19,7 @@ sealed class Screen(val route: String) {
     object PrivacyPolicy : Screen("privacy_policy")
     object CrisisSupport : Screen("crisis_support")
     object EmergencyContactSettings : Screen("emergency_contact_settings")
+    object Profile : Screen("profile")
 
     object Editor : Screen("editor") {
         const val ENTRY_ID_ARG = "entryId"

--- a/backend/alembic/versions/0002_add_profile_fields.py
+++ b/backend/alembic/versions/0002_add_profile_fields.py
@@ -1,0 +1,17 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('name', sa.String(), nullable=True))
+    op.add_column('users', sa.Column('bio', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('users', 'bio')
+    op.drop_column('users', 'name')

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -47,6 +47,25 @@ def login_for_access_token(
     access_token = create_access_token(data={"sub": user.email})
     return {"access_token": access_token, "token_type": "bearer"}
 
+@router.get("/me", response_model=schemas.User)
+def read_current_user(
+        *,
+        current_user: models.User = Depends(deps.get_current_user),
+):
+    """Mendapatkan profil pengguna yang sedang login."""
+    return current_user
+
+@router.put("/me", response_model=schemas.User)
+def update_current_user(
+        *,
+        db: Session = Depends(deps.get_db),
+        user_in: schemas.UserUpdate,
+        current_user: models.User = Depends(deps.get_current_user),
+):
+    """Memperbarui profil pengguna yang sedang login."""
+    user = crud.user.update(db=db, db_obj=current_user, obj_in=user_in)
+    return user
+
 # PERBAIKAN: Menambahkan endpoint baru untuk menghapus akun
 @router.delete("/me", response_model=schemas.User)
 def delete_current_user(

--- a/backend/app/crud/crud_user.py
+++ b/backend/app/crud/crud_user.py
@@ -16,6 +16,8 @@ class CRUDUser(CRUDBase[User, UserCreate, UserCreate]):
             email=obj_in.email,
             hashed_password=get_password_hash(obj_in.password),
             is_active=True,
+            name=obj_in.name,
+            bio=obj_in.bio,
         )
         db.add(db_obj)
         db.commit()

--- a/backend/app/db/models/user.py
+++ b/backend/app/db/models/user.py
@@ -1,7 +1,7 @@
 # Lokasi: ./app/db/models/user.py
 # Deskripsi: Model SQLAlchemy untuk tabel 'users'.
 
-from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy import Column, Integer, String, Boolean, Text
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
 
@@ -11,5 +11,7 @@ class User(Base):
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     is_active = Column(Boolean(), default=True)
+    name = Column(String, nullable=True)
+    bio = Column(Text, nullable=True)
 
     journals = relationship("JournalEntry", back_populates="owner", cascade="all, delete-orphan")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,7 +1,7 @@
 # Lokasi: ./app/schemas/__init__.py
 # Deskripsi: Memudahkan impor skema Pydantic.
 
-from .user import User, UserCreate, LoginRequest
+from .user import User, UserCreate, UserUpdate, LoginRequest
 from .journal import Journal, JournalCreate, JournalUpdate
 from .chat import ChatRequest, ChatResponse
 from .chat_message import (

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -10,9 +10,15 @@ class LoginRequest(BaseModel):
 
 class UserBase(BaseModel):
     email: EmailStr
+    name: str | None = None
+    bio: str | None = None
 
 class UserCreate(UserBase):
     password: str
+
+class UserUpdate(BaseModel):
+    name: str | None = None
+    bio: str | None = None
 
 class User(UserBase):
     id: int


### PR DESCRIPTION
## Summary
- extend backend user model with `name` and `bio`
- create Alembic migration for new columns
- expose `/users/me` GET/PUT endpoints
- adjust schemas and CRUD logic
- add Kotlin data layer for profiles
- provide profile repository, API service and screen
- link profile screen from settings and navigation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c709c988832494331c588565cdf2