### PR TITLE
Fix remove methods to use Session.get

### DIFF
--- a/backend/app/crud/base.py
+++ b/backend/app/crud/base.py
@@ -49,7 +49,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
 
     # PENAMBAHAN/PERBAIKAN: Menambahkan fungsi 'remove' generik
     def remove(self, db: Session, *, id: int) -> Optional[ModelType]:
-        obj = db.query(self.model).get(id)
+        obj = db.get(self.model, id)
         if obj:
             db.delete(obj)
             db.commit()

--- a/backend/app/crud/crud_user.py
+++ b/backend/app/crud/crud_user.py
@@ -27,7 +27,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserCreate]):
     # PERBAIKAN: Menambahkan fungsi remove
     def remove(self, db: Session, *, id: int) -> User | None:
         """Menghapus pengguna berdasarkan ID."""
-        obj = db.query(self.model).get(id)
+        obj = db.get(self.model, id)
         if obj:
             db.delete(obj)
             db.commit()


### PR DESCRIPTION
## Summary
- use `db.get(self.model, id)` in `CRUDBase.remove`
- apply the same update in `CRUDUser.remove`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ca8ae4748324a2ba83f15e1aea09