### PR TITLE
Simplify chat-focused home tab

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.psy.deardiary.data.model.ChatMessage
-import com.psy.deardiary.features.home.components.*
+import com.psy.deardiary.features.home.components.TypingIndicator
 import com.psy.deardiary.features.home.emojiOptions
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalFoundationApi::class) // ANOTASI BARU
@@ -44,7 +44,7 @@ fun HomeScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Hari Ini Untukmu") },
+                title = { Text("${uiState.timeOfDay}, ${uiState.userName}.") },
                 actions = {
                     IconButton(onClick = onNavigateToCrisisSupport) {
                         Icon(Icons.Outlined.CrisisAlert, contentDescription = "Dukungan Krisis")
@@ -64,40 +64,22 @@ fun HomeScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            if (uiState.isLoading) {
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
-                }
-            } else {
-                Column(modifier = Modifier.fillMaxSize()) {
-                    WelcomeCard(
-                        timeOfDay = uiState.timeOfDay,
-                        userName = uiState.userName,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                    )
-                    LazyColumn(
-                        modifier = Modifier.weight(1f),
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                        state = listState,
-                    ) {
-                        items(uiState.feedItems, key = { it.hashCode() }) { item ->
-                            when (item) {
-                                is FeedItem.JournalItem -> JournalItemCard(item.journalEntry)
-                                is FeedItem.ArticleSuggestionItem -> ArticleSuggestionCard(item.article)
-                                is FeedItem.ChatPromptItem -> ChatPromptCard(item.message)
-                            }
-                        }
-                        items(messages, key = { it.id }) { msg ->
-                            AnimatedVisibility(
-                                visible = true,
-                                enter = fadeIn() + slideInVertically { it / 2 },
-                                exit = fadeOut() + slideOutVertically()
-                            ) {
-                                ChatBubble(
-                                    message = msg,
-                                    modifier = Modifier.animateItemPlacement() // PENGGUNAAN animateItemPlacement
-                                )
-                            }
+            Column(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    state = listState,
+                ) {
+                    items(messages, key = { it.id }) { msg ->
+                        AnimatedVisibility(
+                            visible = true,
+                            enter = fadeIn() + slideInVertically { it / 2 },
+                            exit = fadeOut() + slideOutVertically()
+                        ) {
+                            ChatBubble(
+                                message = msg,
+                                modifier = Modifier.animateItemPlacement() // PENGGUNAAN animateItemPlacement
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
@@ -3,8 +3,7 @@ package com.psy.deardiary.features.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psy.deardiary.data.repository.JournalRepository
-import com.psy.deardiary.data.repository.FeedRepository
-import com.psy.deardiary.data.repository.Result
+
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,7 +14,6 @@ import javax.inject.Inject
 
 data class HomeUiState(
     val isLoading: Boolean = true,
-    val feedItems: List<FeedItem> = emptyList(),
     val timeOfDay: String = "",
     val userName: String = ""
 )
@@ -23,33 +21,19 @@ data class HomeUiState(
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val journalRepository: JournalRepository,
-    private val feedRepository: FeedRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState = _uiState.asStateFlow()
 
     init {
-        loadFeedContent()
-    }
-
-    private fun loadFeedContent() {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            when (val result = feedRepository.getFeed()) {
-                is Result.Success -> {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            feedItems = result.data,
-                            timeOfDay = getTimeOfDay(),
-                            userName = "Odang"
-                        )
-                    }
-                }
-                is Result.Error -> {
-                    _uiState.update { it.copy(isLoading = false) }
-                }
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    timeOfDay = getTimeOfDay(),
+                    userName = "Odang"
+                )
             }
         }
     }

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeViewModelTest.kt
@@ -1,6 +1,3 @@
-import com.psy.deardiary.data.repository.FeedRepository
-import com.psy.deardiary.data.repository.Result
-import com.psy.deardiary.features.home.FeedItem
 import com.psy.deardiary.features.home.HomeViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -12,22 +9,18 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
-    private lateinit var repository: FeedRepository
     private lateinit var viewModel: HomeViewModel
 
     @Before
     fun setup() {
         Dispatchers.setMain(dispatcher)
-        repository = mock()
-        whenever(repository.getFeed()).thenReturn(Result.Success(emptyList()))
-        viewModel = HomeViewModel(mock(), repository)
+        viewModel = HomeViewModel(mock())
     }
 
     @After
@@ -36,13 +29,9 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun feedUpdates_whenEntriesEmitted() = runTest {
-        whenever(repository.getFeed()).thenReturn(
-            Result.Success(listOf(FeedItem.ChatPromptItem("hi")))
-        )
-        advanceUntilIdle()
-        val feed = viewModel.uiState.value.feedItems
-        assertEquals(1, feed.size)
-        assertTrue(feed[0] is FeedItem.ChatPromptItem)
+    fun initializesGreeting() = runTest {
+        val state = viewModel.uiState.value
+        assertTrue(state.timeOfDay.isNotBlank())
+        assertEquals("Odang", state.userName)
     }
 }


### PR DESCRIPTION
## Summary
- streamline `HomeViewModel` without article feed
- simplify `HomeScreen` to show only chat history with a dynamic greeting
- update unit test for the new view model behaviour

## Testing
- `pytest` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_6852e214ff388324a3f103da7a6e2ec5