### PR TITLE
Add sentiment fields to chat

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
@@ -4,18 +4,26 @@ import com.google.gson.annotations.SerializedName
 
 data class ChatRequest(val message: String)
 
-data class ChatResponse(val reply: String)
+data class ChatResponse(
+    val reply: String,
+    @SerializedName("sentiment_score") val sentimentScore: Float? = null,
+    @SerializedName("key_emotions") val keyEmotions: String? = null
+)
 
 data class ChatMessageResponse(
     val id: Int,
     val text: String,
     val isUser: Boolean,
     val timestamp: Long,
-    @SerializedName("owner_id") val ownerId: Int
+    @SerializedName("owner_id") val ownerId: Int,
+    @SerializedName("sentiment_score") val sentimentScore: Float? = null,
+    @SerializedName("key_emotions") val keyEmotions: String? = null
 )
 
 data class ChatMessageCreateRequest(
     val text: String,
     val isUser: Boolean,
-    val timestamp: Long
+    val timestamp: Long,
+    @SerializedName("sentiment_score") val sentimentScore: Float? = null,
+    @SerializedName("key_emotions") val keyEmotions: String? = null
 )

--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatMappers.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatMappers.kt
@@ -9,6 +9,8 @@ fun ChatMessageResponse.toChatMessage(): ChatMessage {
         text = this.text,
         isUser = this.isUser,
         timestamp = this.timestamp,
+        sentimentScore = this.sentimentScore,
+        keyEmotions = this.keyEmotions,
         isSynced = true
     )
 }
@@ -17,6 +19,8 @@ fun ChatMessage.toCreateRequest(): ChatMessageCreateRequest {
     return ChatMessageCreateRequest(
         text = this.text,
         isUser = this.isUser,
-        timestamp = this.timestamp
+        timestamp = this.timestamp,
+        sentimentScore = this.sentimentScore,
+        keyEmotions = this.keyEmotions
     )
 }

--- a/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
@@ -13,7 +13,7 @@ import com.psy.deardiary.data.model.ChatMessage
 // --- PERBAIKAN: Naikkan versi database dari 2 menjadi 3 ---
 @Database(
     entities = [JournalEntry::class, ChatMessage::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -26,6 +26,13 @@ abstract class AppDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE chat_messages ADD COLUMN userId INTEGER NOT NULL DEFAULT 0")
                 database.execSQL("ALTER TABLE journal_entries ADD COLUMN userId INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE chat_messages ADD COLUMN sentimentScore REAL")
+                database.execSQL("ALTER TABLE chat_messages ADD COLUMN keyEmotions TEXT")
             }
         }
     }

--- a/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
@@ -15,8 +15,15 @@ interface ChatMessageDao {
     @Query("SELECT * FROM chat_messages WHERE isSynced = 0 AND userId = :userId")
     suspend fun getUnsyncedMessages(userId: Int): List<ChatMessage>
 
-    @Query("UPDATE chat_messages SET remoteId = :remoteId, isSynced = 1 WHERE id = :id")
-    suspend fun markAsSynced(id: Int, remoteId: Int)
+    @Query(
+        "UPDATE chat_messages SET remoteId = :remoteId, sentimentScore = :sentimentScore, keyEmotions = :keyEmotions, isSynced = 1 WHERE id = :id"
+    )
+    suspend fun markAsSynced(
+        id: Int,
+        remoteId: Int,
+        sentimentScore: Float?,
+        keyEmotions: String?
+    )
 
     @Update
     suspend fun updateMessage(message: ChatMessage)

--- a/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
@@ -12,6 +12,8 @@ data class ChatMessage(
     val text: String,
     val isUser: Boolean,
     val timestamp: Long = System.currentTimeMillis(),
+    val sentimentScore: Float? = null,
+    val keyEmotions: String? = null,
     val isSynced: Boolean = false,
     val isPlaceholder: Boolean = false
 )

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -109,8 +109,13 @@ class ChatRepository @Inject constructor(
                 for (msg in unsynced) {
                     val response = chatApiService.postMessage(msg.toCreateRequest())
                     if (response.isSuccessful && response.body() != null) {
-                        val remoteId = response.body()!!.id
-                        chatMessageDao.markAsSynced(msg.id, remoteId)
+                        val body = response.body()!!
+                        chatMessageDao.markAsSynced(
+                            msg.id,
+                            body.id,
+                            body.sentimentScore,
+                            body.keyEmotions
+                        )
                     } else {
                         return@withContext Result.Error("Gagal menyinkronkan pesan")
                     }

--- a/app/src/main/java/com/psy/deardiary/di/AppModule.kt
+++ b/app/src/main/java/com/psy/deardiary/di/AppModule.kt
@@ -41,7 +41,7 @@ object AppModule {
             AppDatabase::class.java,
             "dear_diary_database"
         )
-            .addMigrations(AppDatabase.MIGRATION_3_4)
+            .addMigrations(AppDatabase.MIGRATION_3_4, AppDatabase.MIGRATION_4_5)
             .build()
     }
 


### PR DESCRIPTION
## Summary
- support sentiment score and key emotions in `ChatMessage`
- update DAO, mappers and repository to work with the new fields
- add database migration to version 5
- extend DTO classes and DI configuration

## Testing
- `gradle --no-daemon test` *(fails: SDK location not found)*
- `pytest backend/tests` *(fails: ModuleNotFoundError: email-validator)*

------
https://chatgpt.com/codex/tasks/task_e_685375e74fbc8324ba4791ce71cfcc68