### PR TITLE
Return AI sentiment with chat replies

### DIFF
--- a/backend/tests/test_crud_chat.py
+++ b/backend/tests/test_crud_chat.py
@@ -1,4 +1,9 @@
 import os
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("AI_API_KEY", "test")
+os.environ.setdefault("AI_API_URL", "http://test")
+os.environ.setdefault("AI_MODEL", "test-model")
 import sys
 import pytest
 from sqlalchemy import create_engine

--- a/backend/tests/test_crud_journal.py
+++ b/backend/tests/test_crud_journal.py
@@ -1,4 +1,9 @@
 import os
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("AI_API_KEY", "test")
+os.environ.setdefault("AI_API_URL", "http://test")
+os.environ.setdefault("AI_MODEL", "test-model")
 import sys
 import pytest
 from sqlalchemy import create_engine

--- a/backend/tests/test_crud_user.py
+++ b/backend/tests/test_crud_user.py
@@ -1,4 +1,9 @@
 import os
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("AI_API_KEY", "test")
+os.environ.setdefault("AI_API_URL", "http://test")
+os.environ.setdefault("AI_MODEL", "test-model")
 import sys
 import pytest
 from sqlalchemy import create_engine


### PR DESCRIPTION
## Summary
- call `analyze_sentiment_with_ai` when creating a chat message
- store the sentiment score and key emotions on the chat message
- return sentiment info in `ChatResponse`
- set env vars in tests and test chat API sentiment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685377a72f9883248e64318d9490c4cb