### PR TITLE
Add sentiment data handling to chat flow

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/model/SentimentInfo.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/SentimentInfo.kt
@@ -1,0 +1,6 @@
+package com.psy.deardiary.data.model
+
+data class SentimentInfo(
+    val sentimentScore: Float?,
+    val keyEmotions: String?
+)

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -53,7 +53,13 @@ class HomeChatViewModel @Inject constructor(
             // 5. Ganti pesan placeholder dengan hasil atau pesan kesalahan
             when (result) {
                 is Result.Success -> {
-                    chatRepository.replaceMessage(placeholder.id, result.data)
+                    val (reply, info) = result.data
+                    chatRepository.replaceMessage(
+                        placeholder.id,
+                        reply,
+                        info.sentimentScore,
+                        info.keyEmotions
+                    )
                 }
                 is Result.Error, null -> {
                     chatRepository.replaceMessage(

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
@@ -1,6 +1,7 @@
 import com.psy.deardiary.data.model.ChatMessage
 import com.psy.deardiary.data.repository.ChatRepository
 import com.psy.deardiary.data.repository.Result
+import com.psy.deardiary.data.model.SentimentInfo
 import com.psy.deardiary.features.home.HomeChatViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -45,13 +46,15 @@ class HomeChatViewModelTest {
     fun sendMessage_delegatesToRepository() = runTest {
         whenever(repository.addMessage(any(), eq(true), eq(false))).thenReturn(ChatMessage(text="hi", isUser=true, userId = 1))
         whenever(repository.addMessage(any(), eq(false), eq(true))).thenReturn(ChatMessage(id=2, text="placeholder", isUser=false, isPlaceholder=true, userId = 1))
-        whenever(repository.fetchReply("hi")).thenReturn(Result.Success("hello"))
+        whenever(repository.fetchReply("hi")).thenReturn(
+            Result.Success("hello" to SentimentInfo(0.5f, "happy"))
+        )
         viewModel.sendMessage("hi")
         advanceUntilIdle()
         verify(repository).addMessage("hi", true, false)
         verify(repository).addMessage("Sedang mengetik jawaban...", false, true)
         verify(repository).fetchReply("hi")
-        verify(repository).replaceMessage(2, "hello")
+        verify(repository).replaceMessage(2, "hello", 0.5f, "happy")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- create `SentimentInfo` model
- expose sentiment data when fetching chat reply
- store sentiment when replacing placeholder messages
- handle sentiment in `HomeChatViewModel`
- update unit test for new API

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685378eb51e08324ada2d766f39b62bf