### PR TITLE
Add detected mood to chat messages

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
@@ -17,7 +17,8 @@ data class ChatMessageResponse(
     val timestamp: Long,
     @SerializedName("owner_id") val ownerId: Int,
     @SerializedName("sentiment_score") val sentimentScore: Float? = null,
-    @SerializedName("key_emotions") val keyEmotions: String? = null
+    @SerializedName("key_emotions") val keyEmotions: String? = null,
+    @SerializedName("detected_mood") val detectedMood: String? = null
 )
 
 data class ChatMessageCreateRequest(
@@ -25,5 +26,6 @@ data class ChatMessageCreateRequest(
     val isUser: Boolean,
     val timestamp: Long,
     @SerializedName("sentiment_score") val sentimentScore: Float? = null,
-    @SerializedName("key_emotions") val keyEmotions: String? = null
+    @SerializedName("key_emotions") val keyEmotions: String? = null,
+    @SerializedName("detected_mood") val detectedMood: String? = null
 )

--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatMappers.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatMappers.kt
@@ -11,6 +11,7 @@ fun ChatMessageResponse.toChatMessage(): ChatMessage {
         timestamp = this.timestamp,
         sentimentScore = this.sentimentScore,
         keyEmotions = this.keyEmotions,
+        detectedMood = this.detectedMood,
         isSynced = true
     )
 }
@@ -21,6 +22,7 @@ fun ChatMessage.toCreateRequest(): ChatMessageCreateRequest {
         isUser = this.isUser,
         timestamp = this.timestamp,
         sentimentScore = this.sentimentScore,
-        keyEmotions = this.keyEmotions
+        keyEmotions = this.keyEmotions,
+        detectedMood = this.detectedMood
     )
 }

--- a/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
@@ -13,7 +13,7 @@ import com.psy.deardiary.data.model.ChatMessage
 // --- PERBAIKAN: Naikkan versi database dari 2 menjadi 3 ---
 @Database(
     entities = [JournalEntry::class, ChatMessage::class],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -33,6 +33,12 @@ abstract class AppDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE chat_messages ADD COLUMN sentimentScore REAL")
                 database.execSQL("ALTER TABLE chat_messages ADD COLUMN keyEmotions TEXT")
+            }
+        }
+
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE chat_messages ADD COLUMN detectedMood TEXT")
             }
         }
     }

--- a/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
@@ -16,13 +16,14 @@ interface ChatMessageDao {
     suspend fun getUnsyncedMessages(userId: Int): List<ChatMessage>
 
     @Query(
-        "UPDATE chat_messages SET remoteId = :remoteId, sentimentScore = :sentimentScore, keyEmotions = :keyEmotions, isSynced = 1 WHERE id = :id"
+        "UPDATE chat_messages SET remoteId = :remoteId, sentimentScore = :sentimentScore, keyEmotions = :keyEmotions, detectedMood = :detectedMood, isSynced = 1 WHERE id = :id"
     )
     suspend fun markAsSynced(
         id: Int,
         remoteId: Int,
         sentimentScore: Float?,
-        keyEmotions: String?
+        keyEmotions: String?,
+        detectedMood: String?
     )
 
     @Update

--- a/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
@@ -14,6 +14,7 @@ data class ChatMessage(
     val timestamp: Long = System.currentTimeMillis(),
     val sentimentScore: Float? = null,
     val keyEmotions: String? = null,
+    val detectedMood: String? = null,
     val isSynced: Boolean = false,
     val isPlaceholder: Boolean = false
 )

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -87,7 +87,8 @@ class ChatRepository @Inject constructor(
         id: Int,
         newText: String,
         sentimentScore: Float? = null,
-        keyEmotions: String? = null
+        keyEmotions: String? = null,
+        detectedMood: String? = null
     ) {
         val uid = userPreferencesRepository.userId.first() ?: return
         val existing = chatMessageDao.getMessageById(id, uid) ?: return
@@ -95,7 +96,8 @@ class ChatRepository @Inject constructor(
             text = newText,
             isPlaceholder = false,
             sentimentScore = sentimentScore,
-            keyEmotions = keyEmotions
+            keyEmotions = keyEmotions,
+            detectedMood = detectedMood
         )
         chatMessageDao.updateMessage(updated)
     }
@@ -135,7 +137,8 @@ class ChatRepository @Inject constructor(
                             msg.id,
                             body.id,
                             body.sentimentScore,
-                            body.keyEmotions
+                            body.keyEmotions,
+                            body.detectedMood
                         )
                     } else {
                         return@withContext Result.Error("Gagal menyinkronkan pesan")

--- a/app/src/main/java/com/psy/deardiary/di/AppModule.kt
+++ b/app/src/main/java/com/psy/deardiary/di/AppModule.kt
@@ -41,7 +41,11 @@ object AppModule {
             AppDatabase::class.java,
             "dear_diary_database"
         )
-            .addMigrations(AppDatabase.MIGRATION_3_4, AppDatabase.MIGRATION_4_5)
+            .addMigrations(
+                AppDatabase.MIGRATION_3_4,
+                AppDatabase.MIGRATION_4_5,
+                AppDatabase.MIGRATION_5_6
+            )
             .build()
     }
 


### PR DESCRIPTION
## Summary
- add `detectedMood` column to `ChatMessage` entity
- propagate field through network DTOs and mappers
- update DAO query and repository to sync the mood
- bump DB version and add migration

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68537ecfb0d083248f3295dd7e7edcef