### PR TITLE
Add AiChatResponse and update chat flow

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
@@ -29,3 +29,8 @@ data class ChatMessageCreateRequest(
     @SerializedName("key_emotions") val keyEmotions: String? = null,
     @SerializedName("detected_mood") val detectedMood: String? = null
 )
+
+data class AiChatResponse(
+    @SerializedName("reply_text") val replyText: String,
+    @SerializedName("detected_mood") val detectedMood: String? = null
+)

--- a/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
@@ -1,7 +1,7 @@
 package com.psy.deardiary.data.network
 
 import com.psy.deardiary.data.dto.ChatRequest
-import com.psy.deardiary.data.dto.ChatResponse
+import com.psy.deardiary.data.dto.AiChatResponse
 import com.psy.deardiary.data.dto.ChatMessageCreateRequest
 import com.psy.deardiary.data.dto.ChatMessageResponse
 import retrofit2.Response
@@ -11,7 +11,7 @@ import retrofit2.http.GET
 
 interface ChatApiService {
     @POST("api/v1/chat")
-    suspend fun sendMessage(@Body request: ChatRequest): Response<ChatResponse>
+    suspend fun sendMessage(@Body request: ChatRequest): Response<AiChatResponse>
 
     @GET("api/v1/chat/messages")
     suspend fun getMessages(): Response<List<ChatMessageResponse>>

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -20,7 +20,7 @@ import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 import com.psy.deardiary.data.repository.Result
-import com.psy.deardiary.data.model.SentimentInfo
+import com.psy.deardiary.data.dto.AiChatResponse
 
 @Singleton
 class ChatRepository @Inject constructor(
@@ -102,17 +102,12 @@ class ChatRepository @Inject constructor(
         chatMessageDao.updateMessage(updated)
     }
 
-    suspend fun fetchReply(text: String): Result<Pair<String, SentimentInfo>> {
+    suspend fun fetchReply(text: String): Result<AiChatResponse> {
         return withContext(Dispatchers.IO) {
             try {
                 val response = chatApiService.sendMessage(ChatRequest(text))
                 if (response.isSuccessful && response.body() != null) {
-                    val body = response.body()!!
-                    val info = SentimentInfo(
-                        body.sentimentScore,
-                        body.keyEmotions
-                    )
-                    Result.Success(body.reply to info)
+                    Result.Success(response.body()!!)
                 } else {
                     Result.Error("${'$'}{response.message()}")
                 }

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -55,12 +55,11 @@ class HomeChatViewModel @Inject constructor(
             // 5. Ganti pesan placeholder dengan hasil atau pesan kesalahan
             when (result) {
                 is Result.Success -> {
-                    val (reply, info) = result.data
+                    val response = result.data
                     chatRepository.replaceMessage(
                         placeholder.id,
-                        reply,
-                        info.sentimentScore,
-                        info.keyEmotions
+                        response.replyText,
+                        detectedMood = response.detectedMood
                     )
                 }
                 is Result.Error, null -> {

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
@@ -1,7 +1,7 @@
 import com.psy.deardiary.data.model.ChatMessage
 import com.psy.deardiary.data.repository.ChatRepository
 import com.psy.deardiary.data.repository.Result
-import com.psy.deardiary.data.model.SentimentInfo
+import com.psy.deardiary.data.dto.AiChatResponse
 import com.psy.deardiary.features.home.HomeChatViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -50,14 +50,14 @@ class HomeChatViewModelTest {
         whenever(repository.addMessage(any(), eq(true), eq(false))).thenReturn(ChatMessage(text="hi", isUser=true, userId = 1))
         whenever(repository.addMessage(any(), eq(false), eq(true))).thenReturn(ChatMessage(id=2, text="placeholder", isUser=false, isPlaceholder=true, userId = 1))
         whenever(repository.fetchReply("hi")).thenReturn(
-            Result.Success("hello" to SentimentInfo(0.5f, "happy"))
+            Result.Success(AiChatResponse("hello", "happy"))
         )
         viewModel.sendMessage("hi")
         advanceUntilIdle()
         verify(repository).addMessage("hi", true, false)
         verify(repository).addMessage("Sedang mengetik jawaban...", false, true)
         verify(repository).fetchReply("hi")
-        verify(repository).replaceMessage(2, "hello", 0.5f, "happy")
+        verify(repository).replaceMessage(2, "hello", detectedMood = "happy")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add `AiChatResponse` DTO
- update `ChatApiService.sendMessage` to use `AiChatResponse`
- refactor `ChatRepository.fetchReply` and update caller
- adjust tests for new response type

## Testing
- `pytest -q`
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853811e53b88324a22d8275fd5e3776