### PR TITLE
Update chat sendMessage flow

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -119,6 +119,14 @@ class ChatRepository @Inject constructor(
         }
     }
 
+    suspend fun sendMessage(text: String): Result<AiChatResponse> {
+        return fetchReply(text)
+    }
+
+    suspend fun updateMessageWithReply(id: Int, replyText: String, detectedMood: String? = null) {
+        replaceMessage(id, replyText, detectedMood = detectedMood)
+    }
+
     suspend fun syncPendingMessages(): Result<Unit> {
         return withContext(Dispatchers.IO) {
             try {

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -50,16 +50,16 @@ class HomeChatViewModel @Inject constructor(
             // 4. Panggil API dengan batas waktu lebih lama agar server punya waktu
             //    yang cukup untuk merespons. Batas lama sebelumnya kadang terlalu
             //    singkat sehingga balasan AI tidak sempat diterima sepenuhnya.
-            val result = withTimeoutOrNull(30_000) { chatRepository.fetchReply(text) }
+            val result = withTimeoutOrNull(30_000) { chatRepository.sendMessage(text) }
 
             // 5. Ganti pesan placeholder dengan hasil atau pesan kesalahan
             when (result) {
                 is Result.Success -> {
                     val response = result.data
-                    chatRepository.replaceMessage(
+                    chatRepository.updateMessageWithReply(
                         placeholder.id,
                         response.replyText,
-                        detectedMood = response.detectedMood
+                        response.detectedMood
                     )
                 }
                 is Result.Error, null -> {

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
@@ -49,15 +49,15 @@ class HomeChatViewModelTest {
     fun sendMessage_delegatesToRepository() = runTest {
         whenever(repository.addMessage(any(), eq(true), eq(false))).thenReturn(ChatMessage(text="hi", isUser=true, userId = 1))
         whenever(repository.addMessage(any(), eq(false), eq(true))).thenReturn(ChatMessage(id=2, text="placeholder", isUser=false, isPlaceholder=true, userId = 1))
-        whenever(repository.fetchReply("hi")).thenReturn(
+        whenever(repository.sendMessage("hi")).thenReturn(
             Result.Success(AiChatResponse("hello", "happy"))
         )
         viewModel.sendMessage("hi")
         advanceUntilIdle()
         verify(repository).addMessage("hi", true, false)
         verify(repository).addMessage("Sedang mengetik jawaban...", false, true)
-        verify(repository).fetchReply("hi")
-        verify(repository).replaceMessage(2, "hello", detectedMood = "happy")
+        verify(repository).sendMessage("hi")
+        verify(repository).updateMessageWithReply(2, "hello", "happy")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow ChatRepository to update replies with detected mood
- use ChatRepository.sendMessage from HomeChatViewModel
- adjust tests for new repository helpers

## Testing
- `pip install -r backend/requirements.txt pytest`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853831dea4483248d4eca85168c7156