### PR TITLE
Update Journal sync for sentiment support

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/local/JournalDao.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/JournalDao.kt
@@ -18,8 +18,15 @@ interface JournalDao {
     @Query("SELECT * FROM journal_entries WHERE isSynced = 0 AND userId = :userId")
     suspend fun getUnsyncedEntries(userId: Int): List<JournalEntry>
 
-    @Query("UPDATE journal_entries SET remoteId = :newRemoteId, isSynced = 1 WHERE id = :localId")
-    suspend fun markAsSynced(localId: Int, newRemoteId: Int)
+    @Query(
+        "UPDATE journal_entries SET remoteId = :newRemoteId, sentimentScore = :sentimentScore, keyEmotions = :keyEmotions, isSynced = 1 WHERE id = :localId"
+    )
+    suspend fun markAsSynced(
+        localId: Int,
+        newRemoteId: Int,
+        sentimentScore: Float?,
+        keyEmotions: String?
+    )
 
     @Query("SELECT * FROM journal_entries WHERE remoteId = :remoteId AND userId = :userId LIMIT 1")
     suspend fun getEntryByRemoteId(remoteId: Int?, userId: Int): JournalEntry?
@@ -27,8 +34,21 @@ interface JournalDao {
     @Query("SELECT * FROM journal_entries WHERE id = :id LIMIT 1")
     suspend fun getEntryById(id: Int): JournalEntry?
 
-    @Query("UPDATE journal_entries SET remoteId = :remoteId, title = :title, content = :content, mood = :mood, timestamp = :timestamp, tags = :tags, isSynced = :isSynced WHERE id = :id")
-    suspend fun updateEntry(id: Int, remoteId: Int?, title: String, content: String, mood: String, timestamp: Long, tags: List<String>, isSynced: Boolean)
+    @Query(
+        "UPDATE journal_entries SET remoteId = :remoteId, title = :title, content = :content, mood = :mood, timestamp = :timestamp, tags = :tags, sentimentScore = :sentimentScore, keyEmotions = :keyEmotions, isSynced = :isSynced WHERE id = :id"
+    )
+    suspend fun updateEntry(
+        id: Int,
+        remoteId: Int?,
+        title: String,
+        content: String,
+        mood: String,
+        timestamp: Long,
+        tags: List<String>,
+        sentimentScore: Float?,
+        keyEmotions: String?,
+        isSynced: Boolean
+    )
 
     @Update
     suspend fun updateLocalEntry(entry: JournalEntry)
@@ -62,6 +82,8 @@ interface JournalDao {
                     mood = entry.mood,
                     timestamp = entry.timestamp,
                     tags = entry.tags,
+                    sentimentScore = entry.sentimentScore,
+                    keyEmotions = entry.keyEmotions,
                     isSynced = true
                 )
             }

--- a/app/src/main/java/com/psy/deardiary/data/repository/JournalRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/JournalRepository.kt
@@ -160,8 +160,13 @@ class JournalRepository @Inject constructor(
 
 
                     if (response.isSuccessful && response.body() != null) {
-                        val remoteId = response.body()!!.id
-                        journalDao.markAsSynced(localId = entry.id, newRemoteId = remoteId)
+                        val body = response.body()!!
+                        journalDao.markAsSynced(
+                            localId = entry.id,
+                            newRemoteId = body.id,
+                            sentimentScore = body.sentimentScore?.toFloat(),
+                            keyEmotions = body.keyEmotions
+                        )
                     } else {
                         return@withContext Result.Error("Gagal menyinkronkan entri: ${entry.title}")
                     }

--- a/app/src/main/java/com/psy/deardiary/features/diary/JournalEditorScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/diary/JournalEditorScreen.kt
@@ -282,10 +282,26 @@ private fun JournalEditorScreenPreview() {
             override suspend fun insertEntry(entry: com.psy.deardiary.data.model.JournalEntry) = 1L
             override fun getAllEntries(userId: Int) = kotlinx.coroutines.flow.flowOf(emptyList<com.psy.deardiary.data.model.JournalEntry>())
             override suspend fun getUnsyncedEntries(userId: Int) = emptyList<com.psy.deardiary.data.model.JournalEntry>()
-            override suspend fun markAsSynced(localId: Int, newRemoteId: Int) {}
+            override suspend fun markAsSynced(
+                localId: Int,
+                newRemoteId: Int,
+                sentimentScore: Float?,
+                keyEmotions: String?
+            ) {}
             override suspend fun getEntryByRemoteId(remoteId: Int?, userId: Int) = null
             override suspend fun getEntryById(id: Int) = null
-            override suspend fun updateEntry(id: Int, remoteId: Int?, title: String, content: String, mood: String, timestamp: Long, tags: List<String>, isSynced: Boolean) {}
+            override suspend fun updateEntry(
+                id: Int,
+                remoteId: Int?,
+                title: String,
+                content: String,
+                mood: String,
+                timestamp: Long,
+                tags: List<String>,
+                sentimentScore: Float?,
+                keyEmotions: String?,
+                isSynced: Boolean
+            ) {}
             override suspend fun updateLocalEntry(entry: com.psy.deardiary.data.model.JournalEntry) {}
             override suspend fun deleteAllEntries(userId: Int) {}
             override suspend fun getAllEntriesOnce(userId: Int) = emptyList<com.psy.deardiary.data.model.JournalEntry>()


### PR DESCRIPTION
## Summary
- update `markAsSynced` and `updateEntry` to store sentiment info
- include the sentiment fields in `upsertAll`
- pass sentiment data from server response in `JournalRepository`
- adjust preview fake DAO interface

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685385ae96e88324b90dd6b0dada5f2a