### PR TITLE
Add detected mood field in chat API

### DIFF
--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -75,11 +75,18 @@ async def chat_with_ai(
     )
     crud.chat_message.create_with_owner(db, obj_in=ai_msg, owner_id=current_user.id)
 
+    # Determine a simple mood classification from sentiment score
+    detected_mood = None
+    if analysis_result and analysis_result.get("sentiment_score") is not None:
+        score = analysis_result.get("sentiment_score")
+        detected_mood = "positive" if score > 0.2 else "negative" if score < -0.2 else "neutral"
+
     # Removed artificial delay to improve responsiveness.
     return schemas.ChatResponse(
-        reply=reply,
+        reply_text=reply,
         sentiment_score=analysis_result.get("sentiment_score") if analysis_result else None,
         key_emotions=analysis_result.get("key_emotions") if analysis_result else None,
+        detected_mood=detected_mood,
     )
 
 

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -4,6 +4,7 @@ class ChatRequest(BaseModel):
     message: str
 
 class ChatResponse(BaseModel):
-    reply: str
+    reply_text: str
     sentiment_score: float | None = None
     key_emotions: str | None = None
+    detected_mood: str | None = None

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -122,6 +122,7 @@ def test_chat_sentiment_response(client, monkeypatch):
     resp = client.post("/api/v1/chat/", json={"message": "hello"}, headers=headers)
     assert resp.status_code == 200
     data = resp.json()
-    assert data["reply"] == "hi"
+    assert data["reply_text"] == "hi"
     assert data["sentiment_score"] == 0.5
     assert data["key_emotions"] == "happy"
+    assert data["detected_mood"] == "positive"


### PR DESCRIPTION
## Summary
- include a new `detected_mood` value in `ChatResponse`
- compute a simple mood based on sentiment
- expect the new field and reply key in endpoint tests

## Testing
- `pytest -q backend/tests/test_api_endpoints.py`

------
https://chatgpt.com/codex/tasks/task_e_68538cb692c483249d4f598905c62adf