### PR TITLE
Add EmotionLog model and chat mood tracking

### DIFF
--- a/backend/alembic/versions/0003_add_detected_mood_and_emotion_log.py
+++ b/backend/alembic/versions/0003_add_detected_mood_and_emotion_log.py
@@ -1,0 +1,25 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('chatmessages', sa.Column('detected_mood', sa.String(), nullable=True))
+    op.create_table(
+        'emotionlogs',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id')),
+        sa.Column('timestamp', sa.BigInteger(), nullable=False, index=True),
+        sa.Column('detected_mood', sa.String(), nullable=True),
+        sa.Column('source_text', sa.Text()),
+        sa.Column('source_feature', sa.String()),
+    )
+
+
+def downgrade():
+    op.drop_table('emotionlogs')
+    op.drop_column('chatmessages', 'detected_mood')

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -3,10 +3,11 @@
 
 from fastapi import APIRouter
 from app.api.v1.endpoints import auth, journal
-from app.api.v1.endpoints import chat, feed
+from app.api.v1.endpoints import chat, feed, emotion_log
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/users", tags=["auth"])
 api_router.include_router(journal.router, prefix="/journal", tags=["journal"])
 api_router.include_router(chat.router, prefix="/chat", tags=["chat"])
 api_router.include_router(feed.router, prefix="/feed", tags=["feed"])
+api_router.include_router(emotion_log.router, prefix="/emotion", tags=["emotion"])

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -80,6 +80,21 @@ async def chat_with_ai(
     if analysis_result and analysis_result.get("sentiment_score") is not None:
         score = analysis_result.get("sentiment_score")
         detected_mood = "positive" if score > 0.2 else "negative" if score < -0.2 else "neutral"
+        crud.chat_message.update(
+            db,
+            db_obj=created_user_msg,
+            obj_in={"detected_mood": detected_mood},
+        )
+        crud.emotion_log.create_with_owner(
+            db,
+            obj_in=schemas.EmotionLogCreate(
+                timestamp=int(asyncio.get_event_loop().time() * 1000),
+                detected_mood=detected_mood,
+                source_text=chat_in.message,
+                source_feature="chat_home",
+            ),
+            owner_id=current_user.id,
+        )
 
     # Removed artificial delay to improve responsiveness.
     return schemas.ChatResponse(

--- a/backend/app/api/v1/endpoints/emotion_log.py
+++ b/backend/app/api/v1/endpoints/emotion_log.py
@@ -1,0 +1,27 @@
+from typing import List
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app import crud, models, schemas
+from app.api import deps
+
+router = APIRouter()
+
+@router.post("/", response_model=schemas.EmotionLog)
+def create_emotion_log(
+    *,
+    db: Session = Depends(deps.get_db),
+    log_in: schemas.EmotionLogCreate,
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    return crud.emotion_log.create_with_owner(db, obj_in=log_in, owner_id=current_user.id)
+
+
+@router.get("/", response_model=List[schemas.EmotionLog])
+def read_emotion_logs(
+    *,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    return crud.emotion_log.get_multi_by_owner(db, owner_id=current_user.id, skip=skip, limit=limit)

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -4,3 +4,4 @@
 from .crud_user import user
 from .crud_journal import journal
 from .crud_chat import chat_message
+from .crud_emotion_log import emotion_log

--- a/backend/app/crud/crud_emotion_log.py
+++ b/backend/app/crud/crud_emotion_log.py
@@ -1,0 +1,26 @@
+from typing import List
+from sqlalchemy.orm import Session
+from app.crud.base import CRUDBase
+from app.db.models.emotion_log import EmotionLog
+from app.schemas.emotion_log import EmotionLogCreate, EmotionLogUpdate
+
+class CRUDEmotionLog(CRUDBase[EmotionLog, EmotionLogCreate, EmotionLogUpdate]):
+    def create_with_owner(self, db: Session, *, obj_in: EmotionLogCreate, owner_id: int) -> EmotionLog:
+        obj_in_data = obj_in.model_dump()
+        db_obj = EmotionLog(**obj_in_data, user_id=owner_id)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def get_multi_by_owner(self, db: Session, *, owner_id: int, skip: int = 0, limit: int = 100) -> List[EmotionLog]:
+        return (
+            db.query(self.model)
+            .filter(EmotionLog.user_id == owner_id)
+            .order_by(EmotionLog.timestamp.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+emotion_log = CRUDEmotionLog(EmotionLog)

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -6,3 +6,4 @@ from app.db.base_class import Base
 from app.db.models.user import User
 from app.db.models.journal import JournalEntry
 from app.db.models.chat import ChatMessage
+from app.db.models.emotion_log import EmotionLog

--- a/backend/app/db/models/chat.py
+++ b/backend/app/db/models/chat.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Text, Boolean, BigInteger, ForeignKey, Float
+from sqlalchemy import Column, Integer, Text, Boolean, BigInteger, ForeignKey, Float, String
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
 
@@ -13,5 +13,6 @@ class ChatMessage(Base):
     # Optional sentiment analysis results
     sentiment_score = Column(Float, nullable=True)
     key_emotions = Column(Text, nullable=True)
+    detected_mood = Column(String, nullable=True)
 
     owner = relationship("User")

--- a/backend/app/db/models/emotion_log.py
+++ b/backend/app/db/models/emotion_log.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, Text, BigInteger, ForeignKey
+from sqlalchemy.orm import relationship
+from app.db.base_class import Base
+
+class EmotionLog(Base):
+    __tablename__ = "emotionlogs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    timestamp = Column(BigInteger, nullable=False, index=True)
+    detected_mood = Column(String, nullable=True)
+    source_text = Column(Text)
+    source_feature = Column(String)
+
+    user = relationship("User")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -5,3 +5,4 @@
 from app.db.models.user import User
 from app.db.models.journal import JournalEntry
 from app.db.models.chat import ChatMessage
+from app.db.models.emotion_log import EmotionLog

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -11,3 +11,8 @@ from .chat_message import (
 )
 from .token import Token, TokenData
 from .feed import FeedItem, Article
+from .emotion_log import (
+    EmotionLog,
+    EmotionLogCreate,
+    EmotionLogUpdate,
+)

--- a/backend/app/schemas/chat_message.py
+++ b/backend/app/schemas/chat_message.py
@@ -6,6 +6,7 @@ class ChatMessageBase(BaseModel):
     timestamp: int
     sentiment_score: float | None = None
     key_emotions: str | None = None
+    detected_mood: str | None = None
 
 class ChatMessageCreate(ChatMessageBase):
     pass

--- a/backend/app/schemas/emotion_log.py
+++ b/backend/app/schemas/emotion_log.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+
+class EmotionLogBase(BaseModel):
+    timestamp: int
+    detected_mood: str | None = None
+    source_text: str
+    source_feature: str
+
+class EmotionLogCreate(EmotionLogBase):
+    pass
+
+class EmotionLogUpdate(EmotionLogBase):
+    pass
+
+class EmotionLog(EmotionLogBase):
+    id: int
+    user_id: int
+
+    class Config:
+        from_attributes = True

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -126,3 +126,9 @@ def test_chat_sentiment_response(client, monkeypatch):
     assert data["sentiment_score"] == 0.5
     assert data["key_emotions"] == "happy"
     assert data["detected_mood"] == "positive"
+
+    logs_resp = client.get("/api/v1/emotion/", headers=headers)
+    assert logs_resp.status_code == 200
+    logs = logs_resp.json()
+    assert len(logs) == 1
+    assert logs[0]["detected_mood"] == "positive"


### PR DESCRIPTION
## Summary
- add `detected_mood` field to `ChatMessage`
- introduce new `EmotionLog` model with CRUD and API endpoints
- create Alembic migration for schema changes
- log chat mood whenever chat messages are analyzed
- test emotion log creation in API tests

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538dcae74c8324857bc056a9c6a715