### PR TITLE
Add heuristic mood classifier

### DIFF
--- a/backend/app/services/emotion_classifier.py
+++ b/backend/app/services/emotion_classifier.py
@@ -1,0 +1,42 @@
+"""Simple text-based mood classifier returning an emoji."""
+
+import re
+from typing import Iterable
+
+NEUTRAL_EMOJI = "\U0001F610"
+
+# Keyword groups for heuristic classification
+HAPPY_KEYWORDS: Iterable[str] = [
+    "bahagia", "gembira", "excited", "fantastic", "wonderful", "luar biasa",
+    "sangat senang", "thrilled", "delighted", "amazing"
+]
+POSITIVE_KEYWORDS: Iterable[str] = [
+    "senang", "happy", "good", "great", "oke", "ok", "nice", "pleased", "love",
+    "enjoy"
+]
+SAD_KEYWORDS: Iterable[str] = [
+    "sedih", "sad", "down", "unhappy", "depressed", "kecewa", "murung",
+    "miserable", "gloomy", "bad"
+]
+ANGRY_KEYWORDS: Iterable[str] = [
+    "marah", "angry", "furious", "kesal", "jengkel", "annoyed", "irritated",
+    "frustrated", "geram"
+]
+
+
+def _contains_keywords(text: str, keywords: Iterable[str]) -> bool:
+    lower = text.lower()
+    return any(re.search(r"\b" + re.escape(word) + r"\b", lower) for word in keywords)
+
+
+def detect_mood(text: str) -> str:
+    """Return an emoji describing the mood found in *text*."""
+    if _contains_keywords(text, HAPPY_KEYWORDS):
+        return "\U0001F600"  # 😀 very happy
+    if _contains_keywords(text, POSITIVE_KEYWORDS):
+        return "\U0001F642"  # 🙂 happy
+    if _contains_keywords(text, ANGRY_KEYWORDS):
+        return "\U0001F621"  # 😡 angry
+    if _contains_keywords(text, SAD_KEYWORDS):
+        return "\U0001F622"  # 😢 sad
+    return NEUTRAL_EMOJI

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ passlib[bcrypt]
 python-jose[cryptography]
 python-multipart
 httpx # PENAMBAHAN BARU
+transformers
 
 # Untuk migrasi database
 alembic

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -125,10 +125,10 @@ def test_chat_sentiment_response(client, monkeypatch):
     assert data["reply_text"] == "hi"
     assert data["sentiment_score"] == 0.5
     assert data["key_emotions"] == "happy"
-    assert data["detected_mood"] == "positive"
+    assert data["detected_mood"] == "\U0001F610"
 
     logs_resp = client.get("/api/v1/emotion/", headers=headers)
     assert logs_resp.status_code == 200
     logs = logs_resp.json()
     assert len(logs) == 1
-    assert logs[0]["detected_mood"] == "positive"
+    assert logs[0]["detected_mood"] == "\U0001F610"


### PR DESCRIPTION
## Summary
- implement `detect_mood` in new `emotion_classifier` service
- integrate emoji mood detection in chat endpoint
- add `transformers` to backend requirements
- update API tests for new emoji mood values

## Testing
- `pip install -r backend/requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538f45f77883249643b55a33f7046d