### PR TITLE
Update emotion logs schema

### DIFF
--- a/backend/alembic/versions/0004_update_emotion_log_table.py
+++ b/backend/alembic/versions/0004_update_emotion_log_table.py
@@ -1,0 +1,19 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0004'
+down_revision = '0003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table('emotionlogs', 'emotion_logs')
+    op.add_column('emotion_logs', sa.Column('sentiment_score', sa.Float(), nullable=True))
+    op.add_column('emotion_logs', sa.Column('key_emotions_detected', sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('emotion_logs', 'key_emotions_detected')
+    op.drop_column('emotion_logs', 'sentiment_score')
+    op.rename_table('emotion_logs', 'emotionlogs')

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -90,6 +90,8 @@ async def chat_with_ai(
             detected_mood=detected_mood,
             source_text=chat_in.message,
             source_feature="chat_home",
+            sentiment_score=analysis_result.get("sentiment_score") if analysis_result else None,
+            key_emotions_detected=(analysis_result.get("key_emotions").split(",") if analysis_result and analysis_result.get("key_emotions") else None),
         ),
         owner_id=current_user.id,
     )
@@ -136,6 +138,8 @@ async def create_message(
             detected_mood=detected_mood,
             source_text=message_in.text,
             source_feature="chat_home",
+            sentiment_score=analysis_result.get("sentiment_score") if analysis_result else None,
+            key_emotions_detected=(analysis_result.get("key_emotions").split(",") if analysis_result and analysis_result.get("key_emotions") else None),
         ),
         owner_id=current_user.id,
     )

--- a/backend/app/db/models/emotion_log.py
+++ b/backend/app/db/models/emotion_log.py
@@ -1,9 +1,10 @@
-from sqlalchemy import Column, Integer, String, Text, BigInteger, ForeignKey
+from sqlalchemy import Column, Integer, String, Text, BigInteger, ForeignKey, Float
+from sqlalchemy.types import JSON
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
 
 class EmotionLog(Base):
-    __tablename__ = "emotionlogs"
+    __tablename__ = "emotion_logs"
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"))
@@ -11,5 +12,7 @@ class EmotionLog(Base):
     detected_mood = Column(String, nullable=True)
     source_text = Column(Text)
     source_feature = Column(String)
+    sentiment_score = Column(Float, nullable=True)
+    key_emotions_detected = Column(JSON, nullable=True)
 
     user = relationship("User")

--- a/backend/app/schemas/emotion_log.py
+++ b/backend/app/schemas/emotion_log.py
@@ -5,6 +5,8 @@ class EmotionLogBase(BaseModel):
     detected_mood: str | None = None
     source_text: str
     source_feature: str
+    sentiment_score: float | None = None
+    key_emotions_detected: list[str] | None = None
 
 class EmotionLogCreate(EmotionLogBase):
     pass

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -132,6 +132,8 @@ def test_chat_sentiment_response(client, monkeypatch):
     logs = logs_resp.json()
     assert len(logs) == 1
     assert logs[0]["detected_mood"] == "\U0001F610"
+    assert logs[0]["sentiment_score"] == 0.5
+    assert logs[0]["key_emotions_detected"] == ["happy"]
 
 
 def test_message_post_handler(client, monkeypatch):
@@ -164,3 +166,5 @@ def test_message_post_handler(client, monkeypatch):
     assert logs_resp.status_code == 200
     logs = logs_resp.json()
     assert len(logs) == 1
+    assert logs[0]["sentiment_score"] == 0.2
+    assert logs[0]["key_emotions_detected"] == ["calm"]


### PR DESCRIPTION
## Summary
- update `EmotionLog` model with new fields and table name
- handle new fields in chat endpoints
- add migration for updated `emotion_logs` table
- extend schema and tests for new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853958bb4c4832490e62adabd7582bd