### PR TITLE
Fix preview build error in JournalEditorScreen

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/diary/JournalEditorScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/diary/JournalEditorScreen.kt
@@ -305,6 +305,7 @@ private fun JournalEditorScreenPreview() {
             override suspend fun updateLocalEntry(entry: com.psy.deardiary.data.model.JournalEntry) {}
             override suspend fun deleteAllEntries(userId: Int) {}
             override suspend fun getAllEntriesOnce(userId: Int) = emptyList<com.psy.deardiary.data.model.JournalEntry>()
+            override suspend fun getLatestMood(userId: Int): String? = null
             override suspend fun deleteEntryByLocalId(localId: Int, userId: Int) {}
         }
 


### PR DESCRIPTION
## Summary
- add missing `getLatestMood` override in `JournalEditorScreenPreview`

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6853975dcfd88324be70f92e6c1650ee