### PR TITLE
Refresh messages on HomeChatViewModel init

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -2,6 +2,7 @@ package com.psy.deardiary.features.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import android.util.Log
 import com.psy.deardiary.data.model.ChatMessage
 import com.psy.deardiary.data.repository.ChatRepository
 import com.psy.deardiary.data.repository.Result
@@ -25,6 +26,13 @@ class HomeChatViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            when (val result = chatRepository.refreshMessages()) {
+                is Result.Error -> Log.e(
+                    "HomeChatViewModel",
+                    "refreshMessages failed: ${result.message}"
+                )
+                else -> Unit
+            }
             chatRepository.getConversation().collect { history ->
                 _messages.value = history
             }

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
@@ -37,6 +37,7 @@ class HomeChatViewModelTest {
         sentimentFlow = MutableStateFlow(null)
         whenever(repository.getConversation()).thenReturn(conversationFlow)
         whenever(repository.latestSentiment).thenReturn(sentimentFlow)
+        whenever(repository.refreshMessages()).thenReturn(Result.Success(Unit))
         viewModel = HomeChatViewModel(repository)
     }
 
@@ -66,5 +67,11 @@ class HomeChatViewModelTest {
         conversationFlow.value = listOf(msg)
         advanceUntilIdle()
         assertEquals(listOf(msg), viewModel.messages.value)
+    }
+
+    @Test
+    fun refreshMessages_calledOnInit() = runTest {
+        advanceUntilIdle()
+        verify(repository).refreshMessages()
     }
 }


### PR DESCRIPTION
## Summary
- log and refresh chat messages when HomeChatViewModel starts
- verify refreshMessages call in unit tests

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a203e7f4832485787f6c5b7f1ff8