### PR TITLE
Add feed section and quick notes to home screen

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeViewModel.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psy.deardiary.data.repository.JournalRepository
 import com.psy.deardiary.data.repository.UserRepository
+import com.psy.deardiary.data.repository.FeedRepository
 import com.psy.deardiary.data.repository.Result
+import com.psy.deardiary.features.home.FeedItem
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,11 +26,15 @@ data class HomeUiState(
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val journalRepository: JournalRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val feedRepository: FeedRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState = _uiState.asStateFlow()
+
+    private val _feedItems = MutableStateFlow<List<FeedItem>>(emptyList())
+    val feedItems = _feedItems.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -44,6 +50,11 @@ class HomeViewModel @Inject constructor(
                     userName = name,
                     lastMood = mood
                 )
+            }
+
+            when (val feedResult = feedRepository.getFeed()) {
+                is Result.Success -> _feedItems.value = feedResult.data
+                else -> Unit
             }
         }
     }

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeViewModelTest.kt
@@ -2,6 +2,7 @@ import com.psy.deardiary.features.home.HomeViewModel
 import com.psy.deardiary.data.repository.JournalRepository
 import com.psy.deardiary.data.repository.UserRepository
 import com.psy.deardiary.data.repository.Result
+import com.psy.deardiary.data.repository.FeedRepository
 import com.psy.deardiary.data.model.UserProfile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -23,6 +24,7 @@ class HomeViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private lateinit var journalRepo: JournalRepository
     private lateinit var userRepo: UserRepository
+    private lateinit var feedRepo: FeedRepository
     private lateinit var viewModel: HomeViewModel
 
     @Before
@@ -30,9 +32,11 @@ class HomeViewModelTest {
         Dispatchers.setMain(dispatcher)
         journalRepo = mock()
         userRepo = mock()
+        feedRepo = mock()
         whenever(userRepo.getProfile()).thenReturn(Result.Success(UserProfile(1, "e", "Budi", null)))
         whenever(journalRepo.getLatestMood()).thenReturn("\uD83D\uDE22")
-        viewModel = HomeViewModel(journalRepo, userRepo)
+        whenever(feedRepo.getFeed()).thenReturn(Result.Success(emptyList()))
+        viewModel = HomeViewModel(journalRepo, userRepo, feedRepo)
     }
 
     @After


### PR DESCRIPTION
## Summary
- extend `HomeViewModel` with feed loading from `FeedRepository`
- display feed items and a quick note bar in `HomeScreen`
- update tests for new repository dependency

## Testing
- `gradle test` *(fails: SDK location not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853a4f28fa48324bff2bfc5e35d3e3d