### PR TITLE
Fetch user id from profile after login

### DIFF
--- a/app/src/main/java/com/psy/deardiary/di/AppModule.kt
+++ b/app/src/main/java/com/psy/deardiary/di/AppModule.kt
@@ -129,9 +129,10 @@ object AppModule {
     @Singleton
     fun provideAuthRepository(
         authApiService: AuthApiService,
+        userApiService: UserApiService,
         userPreferencesRepository: UserPreferencesRepository
     ): AuthRepository {
-        return AuthRepository(authApiService, userPreferencesRepository)
+        return AuthRepository(authApiService, userApiService, userPreferencesRepository)
     }
 
     @Provides

--- a/app/src/main/java/com/psy/deardiary/features/auth/LoginScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/auth/LoginScreen.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.launch
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import com.psy.deardiary.data.network.AuthApiService
+import com.psy.deardiary.data.network.UserApiService
 
 @Composable
 fun LoginScreen(
@@ -147,8 +148,14 @@ private fun LoginScreenPreview() {
             .build()
             .create(AuthApiService::class.java)
 
+        val fakeUserApiService = Retrofit.Builder()
+            .baseUrl("http://localhost/")
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(UserApiService::class.java)
+
         val fakeUserPrefsRepo = UserPreferencesRepository(context)
-        val fakeAuthRepo = AuthRepository(fakeAuthApiService, fakeUserPrefsRepo)
+        val fakeAuthRepo = AuthRepository(fakeAuthApiService, fakeUserApiService, fakeUserPrefsRepo)
         val fakeViewModel = AuthViewModel(fakeAuthRepo)
 
         LoginScreen(onNavigateToRegister = {}, authViewModel = fakeViewModel)


### PR DESCRIPTION
## Summary
- inject `UserApiService` into `AuthRepository`
- call profile endpoint after login to store user id
- update DI to provide `UserApiService` to `AuthRepository`
- update preview code accordingly

## Testing
- `pip install -r backend/requirements.txt pytest`
- `pytest`
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a981e6b883249c3d85efd190b8ad