### PR TITLE
Implement proactive chat prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,11 @@ Endpoint ini kini meninjau beberapa pesan terakhir sebelum memberikan balasan.
 Bila relevan, AI dapat menutup jawabannya dengan pertanyaan singkat untuk
 mendorong interaksi. Pertanyaan tidak akan diulang apabila pada balasan
 sebelumnya AI sudah menanyakannya.
+
+### Prompt Otomatis dari AI
+
+Tab Beranda kini dapat memunculkan pesan pembuka otomatis ketika pengguna lama
+tidak berinteraksi. Backend menyediakan endpoint `/api/v1/chat/prompt` yang
+mengumpulkan riwayat jurnal dan percakapan lalu menghasilkan sapaan singkat yang
+selalu diakhiri pertanyaan probing. Endpoint ini menyimpan pesan tersebut dan
+membatasi pemanggilan jika dalam 6 jam terakhir sudah ada prompt serupa.

--- a/app/src/main/java/com/psy/deardiary/data/datastore/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/datastore/UserPreferencesRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -29,6 +30,7 @@ class UserPreferencesRepository @Inject constructor(@ApplicationContext context:
         val EMERGENCY_CONTACT = stringPreferencesKey("emergency_contact_number")
         val USER_ID = intPreferencesKey("user_id")
         val CHAT_ONBOARD_SHOWN = booleanPreferencesKey("chat_onboard_shown")
+        val LAST_AI_PROMPT = longPreferencesKey("last_ai_prompt")
     }
 
     val authToken: Flow<String?> = dataStore.data.map { preferences ->
@@ -42,6 +44,10 @@ class UserPreferencesRepository @Inject constructor(@ApplicationContext context:
 
     val userId: Flow<Int?> = dataStore.data.map { preferences ->
         preferences[PreferencesKeys.USER_ID]
+    }
+
+    val lastAiPrompt: Flow<Long?> = dataStore.data.map { prefs ->
+        prefs[PreferencesKeys.LAST_AI_PROMPT]
     }
 
     val chatOnboardShown: Flow<Boolean> = dataStore.data.map { preferences ->
@@ -63,6 +69,12 @@ class UserPreferencesRepository @Inject constructor(@ApplicationContext context:
     suspend fun setChatOnboardShown(shown: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.CHAT_ONBOARD_SHOWN] = shown
+        }
+    }
+
+    suspend fun setLastAiPrompt(timestamp: Long) {
+        dataStore.edit { prefs ->
+            prefs[PreferencesKeys.LAST_AI_PROMPT] = timestamp
         }
     }
 

--- a/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
@@ -23,4 +23,7 @@ interface ChatApiService {
 
     @HTTP(method = "DELETE", path = "api/v1/chat/messages", hasBody = true)
     suspend fun deleteMessages(@Body request: DeleteMessagesRequest): Response<Unit>
+
+    @POST("api/v1/chat/prompt")
+    suspend fun requestPrompt(): Response<AiChatResponse>
 }

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import com.psy.deardiary.data.datastore.UserPreferencesRepository
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -28,15 +29,25 @@ class HomeChatViewModelTest {
     private lateinit var viewModel: HomeChatViewModel
     private lateinit var conversationFlow: MutableStateFlow<List<ChatMessage>>
     private lateinit var sentimentFlow: MutableStateFlow<Float?>
+    private lateinit var messagesFlow: MutableStateFlow<List<ChatMessage>>
+    private lateinit var lastPromptFlow: MutableStateFlow<Long?>
+    private lateinit var prefRepo: UserPreferencesRepository
 
     @Before
     fun setup() {
         Dispatchers.setMain(dispatcher)
         repository = mock()
+        prefRepo = mock()
         conversationFlow = MutableStateFlow(emptyList())
         sentimentFlow = MutableStateFlow(null)
+        messagesFlow = MutableStateFlow(emptyList())
+        lastPromptFlow = MutableStateFlow(0L)
         whenever(repository.getConversation()).thenReturn(conversationFlow)
         whenever(repository.latestSentiment).thenReturn(sentimentFlow)
+        whenever(repository.messages).thenReturn(messagesFlow)
+        whenever(prefRepo.lastAiPrompt).thenReturn(lastPromptFlow)
+        whenever(repository.userPreferencesRepository).thenReturn(prefRepo)
+        whenever(repository.promptChat()).thenReturn(Result.Success(AiChatResponse("p", null)))
         whenever(repository.refreshMessages()).thenReturn(Result.Success(Unit))
         viewModel = HomeChatViewModel(repository)
     }

--- a/backend/app/crud/crud_chat.py
+++ b/backend/app/crud/crud_chat.py
@@ -40,6 +40,16 @@ class CRUDChatMessage(CRUDBase[ChatMessage, ChatMessageCreate, ChatMessageUpdate
             .all()
         )
 
+    def get_recent_messages(self, db: Session, *, owner_id: int, limit: int) -> List[ChatMessage]:
+        """Return the most recent messages regardless of sender."""
+        return (
+            db.query(self.model)
+            .filter(ChatMessage.owner_id == owner_id)
+            .order_by(self.model.timestamp.desc())
+            .limit(limit)
+            .all()
+        )
+
     def remove_multi(self, db: Session, *, ids: List[int], owner_id: int) -> int:
         """Delete multiple messages belonging to the given owner.
 

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -200,6 +200,22 @@ def test_delete_messages_endpoint(client, monkeypatch):
     assert remaining[0]["id"] == ids[2]
 
 
+def test_prompt_endpoint_rate_limit(client, monkeypatch):
+    headers = register_and_login(client, email="prompt@example.com")
+
+    async def fake_reply(message: str, context: str = "", relationship_level: int = 0):
+        return "hey?"
+
+    monkeypatch.setattr("app.api.v1.endpoints.chat.get_ai_reply", fake_reply)
+
+    resp = client.post("/api/v1/chat/prompt", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["reply_text"] == "hey?"
+
+    second = client.post("/api/v1/chat/prompt", headers=headers)
+    assert second.status_code == 429
+
+
 def test_relationship_level_prompt_variation(client, monkeypatch):
     headers = register_and_login(client, email="rel@example.com")
 


### PR DESCRIPTION
## Summary
- add new `/api/v1/chat/prompt` endpoint to generate proactive messages
- include repo, ViewModel and UI logic for automatic prompts
- record last prompt time in preferences and repository
- test new endpoint and update README with description

## Testing
- `pytest -q`
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685426a145a083248d63cdc27c11b830