### PR TITLE
Display sentiment info in chat bubbles

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -308,6 +308,14 @@ private fun ChatBubble(
                             Text(text = " $mood", fontSize = MaterialTheme.typography.bodyLarge.fontSize)
                         }
                     }
+                    message.sentimentScore?.let { score ->
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "Sentimen: " + String.format("%.2f", score),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                     message.keyEmotions?.takeIf { it.isNotBlank() }?.let { emotions ->
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(


### PR DESCRIPTION
## Summary
- show latest sentiment score in `ChatBubble`
- keep displaying key emotions in a compact style

## Testing
- `pip install -r backend/requirements.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854292d255c8324abbb4cc126edc75b