### PR TITLE
Add dynamic chat context builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,10 @@ tidak berinteraksi. Backend menyediakan endpoint `/api/v1/chat/prompt` yang
 mengumpulkan riwayat jurnal dan percakapan lalu menghasilkan sapaan singkat yang
 selalu diakhiri pertanyaan probing. Endpoint ini menyimpan pesan tersebut dan
 membatasi pemanggilan jika dalam 6 jam terakhir sudah ada prompt serupa.
+
+### Konteks Dinamis Chat
+
+Balasan dari endpoint `/api/v1/chat/` kini mempertimbangkan konteks profil.
+Informasi nama, bio, MBTI (jika ada), waktu saat ini, statistik mood, riwayat
+jurnal terkini, serta percakapan terakhir disusun menjadi satu string dan
+dikirim ke model AI. Hal ini membuat respons terasa lebih personal dan relevan.

--- a/TODO.md
+++ b/TODO.md
@@ -6,3 +6,4 @@
 - [x] Add sentiment analysis for chat messages and store result
 - [x] Expose `sentimentScore` via `ChatRepository`
 - [ ] Display sentiment insights in chat UI
+- [ ] Build dynamic chat context from user profile and recent activity

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,2 +1,3 @@
-# File ini sengaja dikosongkan.
-# Keberadaannya menjadikan direktori 'services' sebuah Python package.
+"""Helper and service utilities used across the backend."""
+
+from .chat_context import build_chat_context

--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy.orm import Session
+
+from app import crud, models
+
+
+def _time_of_day() -> str:
+    hour = datetime.now().hour
+    if 5 <= hour < 12:
+        return "morning"
+    if 12 <= hour < 18:
+        return "afternoon"
+    if 18 <= hour < 22:
+        return "evening"
+    return "night"
+
+
+def build_chat_context(db: Session, user: models.User) -> str:
+    """Assemble a string summarizing user info and recent activity."""
+    journals = crud.journal.get_multi_by_owner(db, owner_id=user.id, limit=5)
+    context_lines = [j.content for j in journals]
+
+    moods: dict[str, int] = {}
+    for j in journals:
+        moods[j.mood] = moods.get(j.mood, 0) + 1
+
+    recent_msgs = crud.chat_message.get_last_user_messages(db, owner_id=user.id, limit=4)
+    message_lines = [m.text for m in recent_msgs]
+
+    mood_summary = ", ".join(f"{m}:{c}" for m, c in moods.items())
+
+    sections: list[str] = []
+    info_parts: list[str] = []
+    if user.name:
+        info_parts.append(user.name)
+    if user.bio:
+        info_parts.append(user.bio)
+    mbti = getattr(user, "mbti", None)
+    if mbti:
+        info_parts.append(f"MBTI: {mbti}")
+    if info_parts:
+        sections.append("User info: " + ", ".join(info_parts))
+
+    sections.append(f"Time of day: {_time_of_day()}")
+    if mood_summary:
+        sections.append(f"Mood frequencies: {mood_summary}")
+    if context_lines:
+        sections.append("Recent journal entries:\n" + "\n".join(context_lines))
+    if message_lines:
+        sections.append("Recent conversation:\n" + "\n".join(message_lines))
+
+    return "\n".join(sections)

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -77,6 +77,7 @@ def test_chat_context_assembly(client, monkeypatch):
         "app.api.v1.endpoints.journal.crud.journal.process_and_update_sentiment",
         lambda *a, **k: None,
     )
+    monkeypatch.setattr("app.services.chat_context._time_of_day", lambda: "morning")
 
     headers = register_and_login(client)
 
@@ -106,13 +107,14 @@ def test_chat_context_assembly(client, monkeypatch):
     assert resp.status_code == 200
 
     expected = (
+        "Time of day: morning\n"
+        "Mood frequencies: sad:1, happy:1\n"
         "Recent journal entries:\n"
         "I am sad\n"
         "I am happy\n"
         "Recent conversation:\n"
         "m2\n"
-        "m1\n"
-        "Mood frequencies: sad:1, happy:1"
+        "m1"
     )
     assert captured["context"] == expected
 
@@ -136,6 +138,7 @@ def test_prompt_context_assembly(client, monkeypatch):
         "app.api.v1.endpoints.journal.crud.journal.process_and_update_sentiment",
         lambda *a, **k: None,
     )
+    monkeypatch.setattr("app.services.chat_context._time_of_day", lambda: "morning")
 
     headers = register_and_login(client, email="prompt@example.com")
 
@@ -165,13 +168,14 @@ def test_prompt_context_assembly(client, monkeypatch):
     assert resp.status_code == 200
 
     expected = (
+        "Time of day: morning\n"
+        "Mood frequencies: sad:1, happy:1\n"
         "Recent journal entries:\n"
         "I am sad\n"
         "I am happy\n"
         "Recent conversation:\n"
         "m2\n"
         "m1\n"
-        "Mood frequencies: sad:1, happy:1\n"
         "Akhiri jawaban dengan pertanyaan singkat yang bersifat probing."
     )
     assert captured["context"] == expected


### PR DESCRIPTION
## Summary
- build helper to assemble user & history context
- use helper in chat endpoints
- test dynamic context contents
- document new behavior
- track dynamic context feature in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685437274a408324b592c39356876f9b