### PR TITLE
Add MBTI support to user model and API

### DIFF
--- a/backend/alembic/versions/0006_add_mbti_type.py
+++ b/backend/alembic/versions/0006_add_mbti_type.py
@@ -1,0 +1,15 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0006'
+down_revision = '0005'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('mbti_type', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('users', 'mbti_type')

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -66,6 +66,17 @@ def update_current_user(
     user = crud.user.update(db=db, db_obj=current_user, obj_in=user_in)
     return user
 
+@router.put("/me/mbti", response_model=schemas.User)
+def update_mbti_type(
+        *,
+        db: Session = Depends(deps.get_db),
+        mbti_in: schemas.UserMBTIUpdate,
+        current_user: models.User = Depends(deps.get_current_user),
+):
+    """Simpan hasil tes MBTI untuk pengguna saat ini."""
+    user = crud.user.update(db=db, db_obj=current_user, obj_in=mbti_in)
+    return user
+
 # PERBAIKAN: Menambahkan endpoint baru untuk menghapus akun
 @router.delete("/me", response_model=schemas.User)
 def delete_current_user(

--- a/backend/app/crud/crud_user.py
+++ b/backend/app/crud/crud_user.py
@@ -18,6 +18,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserCreate]):
             is_active=True,
             name=obj_in.name,
             bio=obj_in.bio,
+            mbti_type=obj_in.mbti_type,
             relationship_level=0,
         )
         db.add(db_obj)

--- a/backend/app/db/models/user.py
+++ b/backend/app/db/models/user.py
@@ -14,5 +14,6 @@ class User(Base):
     name = Column(String, nullable=True)
     bio = Column(Text, nullable=True)
     relationship_level = Column(Integer, default=0)
+    mbti_type = Column(String, nullable=True)
 
     journals = relationship("JournalEntry", back_populates="owner", cascade="all, delete-orphan")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,7 +1,7 @@
 # Lokasi: ./app/schemas/__init__.py
 # Deskripsi: Memudahkan impor skema Pydantic.
 
-from .user import User, UserCreate, UserUpdate, LoginRequest
+from .user import User, UserCreate, UserUpdate, LoginRequest, UserMBTIUpdate
 from .journal import Journal, JournalCreate, JournalUpdate
 from .chat import ChatRequest, ChatResponse
 from .chat_message import (

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -12,6 +12,7 @@ class UserBase(BaseModel):
     email: EmailStr
     name: str | None = None
     bio: str | None = None
+    mbti_type: str | None = None
 
 class UserCreate(UserBase):
     password: str
@@ -20,6 +21,10 @@ class UserUpdate(BaseModel):
     name: str | None = None
     bio: str | None = None
     relationship_level: int | None = None
+    mbti_type: str | None = None
+
+class UserMBTIUpdate(BaseModel):
+    mbti_type: str
 
 class User(UserBase):
     id: int

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -64,6 +64,22 @@ def test_user_registration_login_delete(client):
     assert resp.status_code == 200
 
 
+def test_mbti_update_endpoint(client):
+    headers = register_and_login(client, email="mbti@example.com")
+
+    resp = client.put(
+        "/api/v1/users/me/mbti",
+        json={"mbti_type": "ENTP"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["mbti_type"] == "ENTP"
+
+    check = client.get("/api/v1/users/me", headers=headers)
+    assert check.status_code == 200
+    assert check.json()["mbti_type"] == "ENTP"
+
+
 def test_journal_crud_endpoints(client):
     headers = register_and_login(client)
 

--- a/backend/tests/test_crud_user.py
+++ b/backend/tests/test_crud_user.py
@@ -40,14 +40,20 @@ def test_user_crud_flow(db_session):
     assert new_user.email == "a@b.com"
     assert new_user.hashed_password != "pass"
     assert new_user.relationship_level == 0
+    assert new_user.mbti_type is None
 
     # update
     updated = user.update(db_session, db_obj=new_user, obj_in={"is_active": False})
     assert updated.is_active is False
 
+    # update mbti
+    updated = user.update(db_session, db_obj=new_user, obj_in={"mbti_type": "INTJ"})
+    assert updated.mbti_type == "INTJ"
+
     # get by email
     got = user.get_by_email(db_session, email="a@b.com")
     assert got.id == new_user.id
+    assert got.mbti_type == "INTJ"
 
     # remove
     user.remove(db_session, id=new_user.id)


### PR DESCRIPTION
## Summary
- add optional mbti_type column to user model and migration
- expose mbti_type in schemas
- store mbti_type via /users/me/mbti
- test storing and retrieving mbti_type

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685438e781d08324a0efb623bf511072