### PR TITLE
Centralize error handling with MainViewModel

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/auth/LoginScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/auth/LoginScreen.kt
@@ -23,7 +23,6 @@ import com.psy.deardiary.data.repository.AuthRepository
 import com.psy.deardiary.ui.components.PasswordTextField
 import com.psy.deardiary.ui.components.PrimaryButton
 import com.psy.deardiary.ui.components.PrimaryTextField
-import com.psy.deardiary.ui.components.InfoDialog
 import com.psy.deardiary.ui.theme.DearDiaryTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -36,7 +35,7 @@ import com.psy.deardiary.data.network.UserApiService
 @Composable
 fun LoginScreen(
     onNavigateToRegister: () -> Unit,
-    // Menghapus parameter onLoginClick karena logika akan ditangani oleh ViewModel
+    mainViewModel: com.psy.deardiary.features.main.MainViewModel,
     authViewModel: AuthViewModel = hiltViewModel()
 ) {
     val uiState by authViewModel.uiState.collectAsState()
@@ -45,14 +44,15 @@ fun LoginScreen(
     var password by remember { mutableStateOf("") }
 
     val snackbarHostState = remember { SnackbarHostState() }
-    var showErrorDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(uiState.errorMessage) {
-        showErrorDialog = uiState.errorMessage != null
+        uiState.errorMessage?.let {
+            mainViewModel.showError(it)
+            authViewModel.clearErrorMessage()
+        }
     }
 
     Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.surface
     ) { paddingValues ->
         Box(
@@ -121,16 +121,6 @@ fun LoginScreen(
                 CircularProgressIndicator()
             }
 
-            if (showErrorDialog) {
-                InfoDialog(
-                    onDismissRequest = {
-                        showErrorDialog = false
-                        authViewModel.clearErrorMessage()
-                    },
-                    title = "Login Gagal",
-                    text = uiState.errorMessage ?: "Terjadi kesalahan"
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/com/psy/deardiary/features/auth/RegisterScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/auth/RegisterScreen.kt
@@ -23,7 +23,6 @@ import com.psy.deardiary.ui.components.PasswordTextField
 import com.psy.deardiary.ui.components.PrimaryButton
 import com.psy.deardiary.ui.components.PrimaryTextField
 import com.psy.deardiary.ui.theme.DearDiaryTheme
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,7 +30,8 @@ fun RegisterScreen(
     onNavigateToLogin: () -> Unit,
     onBackClick: () -> Unit,
     // Menghapus parameter onRegisterClick dan isLoading
-    authViewModel: AuthViewModel = hiltViewModel()
+    authViewModel: AuthViewModel = hiltViewModel(),
+    mainViewModel: com.psy.deardiary.features.main.MainViewModel
 ) {
     val uiState by authViewModel.uiState.collectAsState()
     var email by remember { mutableStateOf("") }
@@ -39,21 +39,14 @@ fun RegisterScreen(
     var confirmPassword by remember { mutableStateOf("") }
     var passwordError by remember { mutableStateOf<String?>(null) }
 
-    val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
-
-    // Menampilkan Snackbar ketika ada errorMessage dari ViewModel
     LaunchedEffect(uiState.errorMessage) {
         uiState.errorMessage?.let { message ->
-            scope.launch {
-                snackbarHostState.showSnackbar(message)
-                authViewModel.clearErrorMessage()
-            }
+            mainViewModel.showError(message)
+            authViewModel.clearErrorMessage()
         }
     }
 
     Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = {},

--- a/app/src/main/java/com/psy/deardiary/features/diary/JournalEditorScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/diary/JournalEditorScreen.kt
@@ -42,7 +42,8 @@ import android.provider.Settings
 @Composable
 fun JournalEditorScreen(
     onBackClick: () -> Unit,
-    viewModel: JournalEditorViewModel = hiltViewModel()
+    viewModel: JournalEditorViewModel = hiltViewModel(),
+    mainViewModel: com.psy.deardiary.features.main.MainViewModel
 ) {
     val uiState by viewModel.uiState.collectAsState()
     var showDeleteDialog by remember { mutableStateOf(false) } // State untuk dialog
@@ -72,6 +73,13 @@ fun JournalEditorScreen(
         if (uiState.isDeleted) {
             onBackClick()
             viewModel.onDeleteComplete()
+        }
+    }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let { message ->
+            mainViewModel.showError(message)
+            viewModel.clearErrorMessage()
         }
     }
 

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -35,7 +35,6 @@ import com.psy.deardiary.features.home.components.JournalItemCard
 import com.psy.deardiary.features.home.components.ArticleSuggestionCard
 import com.psy.deardiary.features.home.components.ChatPromptCard
 import com.psy.deardiary.features.home.FeedItem
-import com.psy.deardiary.ui.components.InfoDialog
 import com.psy.deardiary.ui.components.ConfirmationDialog
 import com.psy.deardiary.utils.playNotificationFeedback
 
@@ -44,6 +43,7 @@ import com.psy.deardiary.utils.playNotificationFeedback
 fun HomeScreen(
     onNavigateToSettings: () -> Unit,
     onNavigateToCrisisSupport: () -> Unit,
+    mainViewModel: com.psy.deardiary.features.main.MainViewModel,
     viewModel: HomeViewModel = hiltViewModel(),
     chatViewModel: HomeChatViewModel = hiltViewModel()
 ) {
@@ -58,10 +58,11 @@ fun HomeScreen(
     var previousCount by remember { mutableStateOf(0) }
     var showDeleteDialog by remember { mutableStateOf(false) }
 
-    var showErrorDialog by remember { mutableStateOf(false) }
-
     LaunchedEffect(chatUiState.errorMessage) {
-        showErrorDialog = chatUiState.errorMessage != null
+        chatUiState.errorMessage?.let {
+            mainViewModel.showError(it)
+            chatViewModel.clearErrorMessage()
+        }
     }
 
     LaunchedEffect(messages, feedItems) {
@@ -163,15 +164,6 @@ fun HomeScreen(
                     onConfirm = { chatViewModel.deleteSelectedMessages() },
                     title = "Hapus Pesan",
                     text = "Hapus pesan yang dipilih?"
-                )
-            } else if (showErrorDialog) {
-                InfoDialog(
-                    onDismissRequest = {
-                        showErrorDialog = false
-                        chatViewModel.clearErrorMessage()
-                    },
-                    title = "Sinkronisasi Gagal",
-                    text = chatUiState.errorMessage ?: "Terjadi kesalahan"
                 )
             }
         }

--- a/app/src/main/java/com/psy/deardiary/features/main/MainViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/main/MainViewModel.kt
@@ -1,0 +1,21 @@
+package com.psy.deardiary.features.main
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor() : ViewModel() {
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage = _errorMessage.asStateFlow()
+
+    fun showError(message: String) {
+        _errorMessage.value = message
+    }
+
+    fun clearError() {
+        _errorMessage.value = null
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/psy/deardiary/navigation/AppNavigation.kt
@@ -9,6 +9,7 @@ import com.psy.deardiary.features.auth.*
 import com.psy.deardiary.features.crisis_support.CrisisSupportScreen
 import com.psy.deardiary.features.diary.JournalEditorScreen
 import com.psy.deardiary.features.main.MainScreen
+import com.psy.deardiary.features.main.MainViewModel
 import com.psy.deardiary.features.onboarding.OnboardingScreen
 import com.psy.deardiary.features.services.dass.DassResultScreen
 import com.psy.deardiary.features.services.dass.DassTestScreen
@@ -49,8 +50,10 @@ fun AppNavigation(navController: NavHostController) {
                 }
             }
 
+            val mainViewModel: MainViewModel = hiltViewModel()
             LoginScreen(
-                onNavigateToRegister = { navController.navigate(Screen.Register.route) }
+                onNavigateToRegister = { navController.navigate(Screen.Register.route) },
+                mainViewModel = mainViewModel
             )
         }
 
@@ -67,20 +70,23 @@ fun AppNavigation(navController: NavHostController) {
                 }
             }
 
+            val mainViewModel: MainViewModel = hiltViewModel()
             RegisterScreen(
                 onNavigateToLogin = {
                     navController.navigate(Screen.Login.route) {
                         popUpTo(Screen.Register.route) { inclusive = true }
                     }
                 },
-                onBackClick = { navController.popBackStack() }
+                onBackClick = { navController.popBackStack() },
+                mainViewModel = mainViewModel
             )
         }
 
         // --- UTAMA ---
 
         composable(Screen.MainAppFlow.route) {
-            MainScreen(mainNavController = navController)
+            val mainViewModel: MainViewModel = hiltViewModel()
+            MainScreen(mainNavController = navController, mainViewModel = mainViewModel)
         }
 
         // --- JURNAL ---
@@ -89,8 +95,10 @@ fun AppNavigation(navController: NavHostController) {
             route = Screen.Editor.route,
             arguments = Screen.Editor.arguments
         ) {
+            val mainViewModel: MainViewModel = hiltViewModel()
             JournalEditorScreen(
-                onBackClick = { navController.popBackStack() }
+                onBackClick = { navController.popBackStack() },
+                mainViewModel = mainViewModel
             )
         }
 

--- a/app/src/main/java/com/psy/deardiary/ui/components/AppStates.kt
+++ b/app/src/main/java/com/psy/deardiary/ui/components/AppStates.kt
@@ -30,7 +30,8 @@ fun NetworkErrorSnackbar(
                 // Bisa ditambahkan jika ingin ada tombol close
             }
         ) {
-            Text(message)
+            val text = data.visuals.message.ifBlank { message }
+            Text(text)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add MainViewModel for app-wide error messages
- display NetworkErrorSnackbar in MainScreen
- route Login, Register, Home, and Journal screens through MainViewModel
- remove old per-screen error dialogs/snackbars

## Testing
- `pip install -r backend/requirements.txt pytest`
- `pytest`
- `./gradlew build -x test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68545624efa083248d3933d6ec458a32