### PR TITLE
Improve AI_API_KEY validation

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
@@ -16,6 +17,13 @@ class Settings(BaseSettings):
     AI_API_KEY: str
     AI_API_URL: str
     AI_MODEL: str  # Perbaikan untuk error 'AttributeError' sebelumnya
+
+    @field_validator("AI_API_KEY")
+    @classmethod
+    def check_api_key(cls, v: str) -> str:
+        if not v or v == "CHANGE_ME":
+            raise ValueError("AI_API_KEY must be set to a real API key")
+        return v
 
     # Konfigurasi Pydantic untuk memuat dari file .env di direktori yang sama
     # saat aplikasi dijalankan (yaitu dari dalam folder 'backend')

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,0 +1,28 @@
+import os
+import importlib
+import pytest
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Set required env variables
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["SECRET_KEY"] = "test"
+os.environ["AI_API_URL"] = "http://test"
+os.environ["AI_MODEL"] = "test-model"
+os.environ["AI_API_KEY"] = "initial"
+
+from app.core import config
+
+
+def test_ai_api_key_placeholder():
+    os.environ["AI_API_KEY"] = "CHANGE_ME"
+    with pytest.raises(ValueError):
+        importlib.reload(config)
+
+
+def test_ai_api_key_valid():
+    os.environ["AI_API_KEY"] = "validkey"
+    module = importlib.reload(config)
+    assert module.Settings().AI_API_KEY == "validkey"
+


### PR DESCRIPTION
## Summary
- add pydantic validator to check that `AI_API_KEY` is not empty or `CHANGE_ME`
- create tests ensuring configuration fails for placeholder values

## Testing
- `pytest backend/tests/test_config_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685485ea46d88324b966f58d292a9d08