### PR TITLE
Add helpful docs to API route decorators

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -10,7 +10,12 @@ from app.core.security import create_access_token, verify_password
 
 router = APIRouter()
 
-@router.post("/register", response_model=schemas.User)
+@router.post(
+    "/register",
+    response_model=schemas.User,
+    summary="Register user",
+    description="Create a new account using email and password.",
+)
 def register_user(
         *,
         db: Session = Depends(deps.get_db),
@@ -26,7 +31,12 @@ def register_user(
     user = crud.user.create(db, obj_in=user_in)
     return user
 
-@router.post("/login", response_model=schemas.Token)
+@router.post(
+    "/login",
+    response_model=schemas.Token,
+    summary="Login",
+    description="Authenticate and receive an access token.",
+)
 def login_for_access_token(
         *,
         db: Session = Depends(deps.get_db),
@@ -47,7 +57,12 @@ def login_for_access_token(
     access_token = create_access_token(data={"sub": user.email})
     return {"access_token": access_token, "token_type": "bearer"}
 
-@router.get("/me", response_model=schemas.User)
+@router.get(
+    "/me",
+    response_model=schemas.User,
+    summary="Get current user",
+    description="Retrieve the profile of the logged in account.",
+)
 def read_current_user(
         *,
         current_user: models.User = Depends(deps.get_current_user),
@@ -55,7 +70,12 @@ def read_current_user(
     """Mendapatkan profil pengguna yang sedang login."""
     return current_user
 
-@router.put("/me", response_model=schemas.User)
+@router.put(
+    "/me",
+    response_model=schemas.User,
+    summary="Update profile",
+    description="Edit email, display name or other account details.",
+)
 def update_current_user(
         *,
         db: Session = Depends(deps.get_db),
@@ -66,7 +86,12 @@ def update_current_user(
     user = crud.user.update(db=db, db_obj=current_user, obj_in=user_in)
     return user
 
-@router.put("/me/mbti", response_model=schemas.User)
+@router.put(
+    "/me/mbti",
+    response_model=schemas.User,
+    summary="Save MBTI result",
+    description="Store the MBTI personality type for the current user.",
+)
 def update_mbti_type(
         *,
         db: Session = Depends(deps.get_db),
@@ -78,7 +103,12 @@ def update_mbti_type(
     return user
 
 # PERBAIKAN: Menambahkan endpoint baru untuk menghapus akun
-@router.delete("/me", response_model=schemas.User)
+@router.delete(
+    "/me",
+    response_model=schemas.User,
+    summary="Delete account",
+    description="Permanently remove the logged in user.",
+)
 def delete_current_user(
         *,
         db: Session = Depends(deps.get_db),

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -14,7 +14,12 @@ from app.tasks import process_chat_sentiment
 
 router = APIRouter()
 
-@router.post("/", response_model=schemas.ChatResponse)
+@router.post(
+    "/",
+    response_model=schemas.ChatResponse,
+    summary="Chat with AI",
+    description="Send a message and get a short AI-generated reply with sentiment analysis.",
+)
 async def chat_with_ai(
     *,
     db: Session = Depends(deps.get_db),
@@ -92,7 +97,12 @@ async def chat_with_ai(
     )
 
 
-@router.post("/messages", response_model=schemas.ChatResponse)
+@router.post(
+    "/messages",
+    response_model=schemas.ChatResponse,
+    summary="Create message",
+    description="Store a chat message and receive an AI response plus sentiment data.",
+)
 async def create_message(
     *,
     db: Session = Depends(deps.get_db),
@@ -148,7 +158,12 @@ async def create_message(
     )
 
 
-@router.post("/prompt", response_model=schemas.ChatResponse)
+@router.post(
+    "/prompt",
+    response_model=schemas.ChatResponse,
+    summary="Generate prompt",
+    description="Let the AI start the conversation when you're inactive.",
+)
 async def prompt_chat(
     *,
     db: Session = Depends(deps.get_db),
@@ -188,7 +203,12 @@ async def prompt_chat(
     return schemas.ChatResponse(reply_text=reply)
 
 
-@router.get("/messages", response_model=List[schemas.ChatMessage])
+@router.get(
+    "/messages",
+    response_model=List[schemas.ChatMessage],
+    summary="Read messages",
+    description="Fetch chat history for the current user.",
+)
 def read_messages(
     *,
     db: Session = Depends(deps.get_db),
@@ -202,7 +222,12 @@ def read_messages(
     )
 
 
-@router.delete("/messages", response_model=int)
+@router.delete(
+    "/messages",
+    response_model=int,
+    summary="Delete messages",
+    description="Remove one or more chat messages by ID.",
+)
 def delete_messages(
     *,
     db: Session = Depends(deps.get_db),

--- a/backend/app/api/v1/endpoints/emotion_log.py
+++ b/backend/app/api/v1/endpoints/emotion_log.py
@@ -6,7 +6,12 @@ from app.api import deps
 
 router = APIRouter()
 
-@router.post("/", response_model=schemas.EmotionLog)
+@router.post(
+    "/",
+    response_model=schemas.EmotionLog,
+    summary="Log emotion",
+    description="Store a timestamped emotion reading from mood detection.",
+)
 def create_emotion_log(
     *,
     db: Session = Depends(deps.get_db),
@@ -16,7 +21,12 @@ def create_emotion_log(
     return crud.emotion_log.create_with_owner(db, obj_in=log_in, owner_id=current_user.id)
 
 
-@router.get("/", response_model=List[schemas.EmotionLog])
+@router.get(
+    "/",
+    response_model=List[schemas.EmotionLog],
+    summary="List emotion logs",
+    description="Return emotion logs belonging to the current user.",
+)
 def read_emotion_logs(
     *,
     db: Session = Depends(deps.get_db),

--- a/backend/app/api/v1/endpoints/feed.py
+++ b/backend/app/api/v1/endpoints/feed.py
@@ -9,7 +9,12 @@ from app.api import deps
 
 router = APIRouter()
 
-@router.get("/", response_model=List[schemas.FeedItem])
+@router.get(
+    "/",
+    response_model=List[schemas.FeedItem],
+    summary="Get personalized feed",
+    description="Return journal highlights, suggested articles or chat prompts based on recent activity.",
+)
 def read_feed(
     *,
     db: Session = Depends(deps.get_db),

--- a/backend/app/api/v1/endpoints/journal.py
+++ b/backend/app/api/v1/endpoints/journal.py
@@ -10,7 +10,13 @@ from app.api import deps
 router = APIRouter()
 
 
-@router.post("/", response_model=schemas.Journal, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/",
+    response_model=schemas.Journal,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create journal entry",
+    description="Write a new journal entry and trigger background sentiment analysis.",
+)
 def create_journal(
     *,
     db: Session = Depends(deps.get_db),
@@ -27,7 +33,12 @@ def create_journal(
     return journal
 
 
-@router.get("/", response_model=List[schemas.Journal])
+@router.get(
+    "/",
+    response_model=List[schemas.Journal],
+    summary="Read journals",
+    description="List all journal entries belonging to the current user.",
+)
 def read_journals(
     # --- PERBAIKAN: Memastikan semua parameter ada di sini ---
     db: Session = Depends(deps.get_db),
@@ -43,7 +54,12 @@ def read_journals(
     return journals
 
 
-@router.put("/{id}", response_model=schemas.Journal)
+@router.put(
+    "/{id}",
+    response_model=schemas.Journal,
+    summary="Update journal entry",
+    description="Edit an existing journal entry and re-run sentiment analysis.",
+)
 def update_journal(
     *,
     db: Session = Depends(deps.get_db),
@@ -69,7 +85,12 @@ def update_journal(
     return updated_journal
 
 
-@router.delete("/{id}", response_model=schemas.Journal)
+@router.delete(
+    "/{id}",
+    response_model=schemas.Journal,
+    summary="Delete journal entry",
+    description="Remove a journal entry permanently.",
+)
 def delete_journal(
     *,
     db: Session = Depends(deps.get_db),


### PR DESCRIPTION
## Summary
- document all auth endpoints
- document chat endpoints
- add summary/description to journal endpoints
- cover emotion_log and feed routes

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68548e0475cc8324bfb556561e43539a