### PR TITLE
Fix preview functions requiring MainViewModel

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/auth/LoginScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/auth/LoginScreen.kt
@@ -147,7 +147,12 @@ private fun LoginScreenPreview() {
         val fakeUserPrefsRepo = UserPreferencesRepository(context)
         val fakeAuthRepo = AuthRepository(fakeAuthApiService, fakeUserApiService, fakeUserPrefsRepo)
         val fakeViewModel = AuthViewModel(fakeAuthRepo)
+        val fakeMainViewModel = com.psy.deardiary.features.main.MainViewModel()
 
-        LoginScreen(onNavigateToRegister = {}, authViewModel = fakeViewModel)
+        LoginScreen(
+            onNavigateToRegister = {},
+            mainViewModel = fakeMainViewModel,
+            authViewModel = fakeViewModel
+        )
     }
 }

--- a/app/src/main/java/com/psy/deardiary/features/auth/RegisterScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/auth/RegisterScreen.kt
@@ -150,9 +150,11 @@ fun RegisterScreen(
 @Composable
 private fun RegisterScreenPreview() {
     DearDiaryTheme {
+        val fakeMainViewModel = com.psy.deardiary.features.main.MainViewModel()
         RegisterScreen(
             onNavigateToLogin = {},
             onBackClick = {},
+            mainViewModel = fakeMainViewModel
         )
     }
 }

--- a/app/src/main/java/com/psy/deardiary/features/diary/JournalEditorScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/diary/JournalEditorScreen.kt
@@ -334,7 +334,12 @@ private fun JournalEditorScreenPreview() {
             context,
             androidx.lifecycle.SavedStateHandle()
         )
+        val fakeMainViewModel = com.psy.deardiary.features.main.MainViewModel()
 
-        JournalEditorScreen(onBackClick = {}, viewModel = vm)
+        JournalEditorScreen(
+            onBackClick = {},
+            viewModel = vm,
+            mainViewModel = fakeMainViewModel
+        )
     }
 }


### PR DESCRIPTION
## Summary
- supply MainViewModel to Login, Register and JournalEditor previews

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6854975aeb6883248151a5df378f5d7e