### PR TITLE
Improve dotenv loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Backend menggunakan FastAPI dan SQLAlchemy. Skema database dikelola melalui Alem
 
    > **Catatan**: File `.env` berisi informasi sensitif dan telah dimasukkan ke `.gitignore`. Pastikan Anda tidak meng-commit file ini ke repository publik.
 
+   Aplikasi akan otomatis mencari dan memuat berkas `.env` baik di folder `backend/` maupun di direktori root proyek.
+
 2. Install dependensi Python:
 
    ```bash

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
-from dotenv import load_dotenv  # <-- 1. TAMBAHKAN IMPORT INI
-load_dotenv()                   # <-- 2. PANGGIL FUNGSI INI DI SINI
+from dotenv import load_dotenv, find_dotenv  # <-- 1. TAMBAHKAN IMPORT INI
+load_dotenv(find_dotenv())                   # <-- 2. PANGGIL FUNGSI INI DI SINI
 
 from app.core import logging as log_setup
 log_setup.setup_logging()


### PR DESCRIPTION
## Summary
- ensure backend reads `.env` from root or backend with `find_dotenv`
- note in README that both locations are supported

## Testing
- `pip install -r backend/requirements.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549d6f47f48324843e898610bfd6d0