### PR TITLE
Prevent duplicate chat messages

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
@@ -13,7 +13,7 @@ import com.psy.deardiary.data.model.ChatMessage
 // --- PERBAIKAN: Naikkan versi database dari 2 menjadi 3 ---
 @Database(
     entities = [JournalEntry::class, ChatMessage::class],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -39,6 +39,14 @@ abstract class AppDatabase : RoomDatabase() {
         val MIGRATION_5_6 = object : Migration(5, 6) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE chat_messages ADD COLUMN detectedMood TEXT")
+            }
+        }
+
+        val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS index_chat_messages_remoteId_userId ON chat_messages(remoteId, userId)"
+                )
             }
         }
     }

--- a/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
@@ -32,6 +32,9 @@ interface ChatMessageDao {
     @Query("SELECT * FROM chat_messages WHERE id = :id AND userId = :userId LIMIT 1")
     suspend fun getMessageById(id: Int, userId: Int): ChatMessage?
 
+    @Query("SELECT * FROM chat_messages WHERE remoteId IS :remoteId AND userId = :userId LIMIT 1")
+    suspend fun getMessageByRemoteId(remoteId: Int?, userId: Int): ChatMessage?
+
     @Query("DELETE FROM chat_messages WHERE userId = :userId")
     suspend fun deleteAllMessages(userId: Int)
 
@@ -41,7 +44,7 @@ interface ChatMessageDao {
     @Transaction
     suspend fun upsertAll(messages: List<ChatMessage>) {
         messages.forEach { message ->
-            val existing = getMessageById(message.id, message.userId)
+            val existing = getMessageByRemoteId(message.remoteId, message.userId)
             if (existing == null) {
                 insertMessage(message)
             } else {

--- a/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/ChatMessage.kt
@@ -1,9 +1,13 @@
 package com.psy.deardiary.data.model
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "chat_messages")
+@Entity(
+    tableName = "chat_messages",
+    indices = [Index(value = ["remoteId", "userId"], unique = true)]
+)
 data class ChatMessage(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,

--- a/app/src/main/java/com/psy/deardiary/di/AppModule.kt
+++ b/app/src/main/java/com/psy/deardiary/di/AppModule.kt
@@ -44,7 +44,8 @@ object AppModule {
             .addMigrations(
                 AppDatabase.MIGRATION_3_4,
                 AppDatabase.MIGRATION_4_5,
-                AppDatabase.MIGRATION_5_6
+                AppDatabase.MIGRATION_5_6,
+                AppDatabase.MIGRATION_6_7
             )
             .build()
     }


### PR DESCRIPTION
## Summary
- add unique index for `remoteId` and `userId` on chat messages
- locate existing chat messages by `remoteId`
- migrate DB to create the unique index
- include new migration in `AppModule`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ac8aa6c483248cb3d83efa153523