### PR TITLE
Handle duplicates before unique index

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/AppDatabase.kt
@@ -45,6 +45,17 @@ abstract class AppDatabase : RoomDatabase() {
         val MIGRATION_6_7 = object : Migration(6, 7) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL(
+                    """
+                    DELETE FROM chat_messages
+                    WHERE remoteId IS NOT NULL AND rowid NOT IN (
+                        SELECT MIN(rowid)
+                        FROM chat_messages
+                        WHERE remoteId IS NOT NULL
+                        GROUP BY remoteId, userId
+                    )
+                    """.trimIndent()
+                )
+                database.execSQL(
                     "CREATE UNIQUE INDEX IF NOT EXISTS index_chat_messages_remoteId_userId ON chat_messages(remoteId, userId)"
                 )
             }


### PR DESCRIPTION
## Summary
- prune duplicate chat messages in migration 6->7
- recreate the unique index after removing duplicates

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b08dc8988324bf5e8acc7c3ab05e