### PR TITLE
Fix Celery worker registration issue

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -14,3 +14,8 @@ celery_app.conf.task_serializer = "json"
 celery_app.conf.result_serializer = "json"
 celery_app.conf.accept_content = ["json"]
 celery_app.conf.timezone = "UTC"
+
+# Automatically discover task modules within the ``app`` package so that
+# running the worker with ``-A backend.app.celery_app.celery_app`` will
+# properly register tasks like ``app.tasks.process_chat_sentiment``.
+celery_app.autodiscover_tasks(["app"])


### PR DESCRIPTION
## Summary
- autodiscover task modules in Celery configuration so that workers
  started with `-A backend.app.celery_app.celery_app` register `app.tasks`
  automatically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx, sqlalchemy, structlog)*

------
https://chatgpt.com/codex/tasks/task_e_6854b48031308324bad5c6a8ff69418c