### PR TITLE
Add attribution for MediaRecorder

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
+    <attribution android:tag="record_audio" android:label="@string/record_audio_attribution"/>
 
     <application
         android:name=".DearDiaryApplication"

--- a/app/src/main/java/com/psy/deardiary/utils/AudioRecorder.kt
+++ b/app/src/main/java/com/psy/deardiary/utils/AudioRecorder.kt
@@ -25,7 +25,8 @@ class AudioRecorder @Inject constructor(
 
     private fun createRecorder(): MediaRecorder {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            MediaRecorder(context)
+            val attributedContext = context.createAttributionContext("record_audio")
+            MediaRecorder(attributedContext)
         } else {
             @Suppress("DEPRECATION")
             MediaRecorder()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="onboarding_welcome">Selamat Datang di Dear Diary</string>
     <string name="onboarding_reflect">Ruang aman untuk merefleksikan harimu.</string>
     <string name="onboarding_private">Pikiranmu aman dan pribadi di sini.</string>
+    <string name="record_audio_attribution">Audio recording</string>
 </resources>


### PR DESCRIPTION
## Summary
- register `record_audio` attribution tag in AndroidManifest
- document attribution text in `strings.xml`
- use attribution context when creating `MediaRecorder`

## Testing
- `gradle test --no-daemon --console=plain` *(fails: Calculating task graph as no cached configuration is available)*

------
https://chatgpt.com/codex/tasks/task_e_6854bbaf1754832483239545fd13b69a