### PR TITLE
Update chat sync logic

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
@@ -32,7 +32,10 @@ data class ChatMessageCreateRequest(
 
 data class AiChatResponse(
     @SerializedName("reply_text") val replyText: String,
-    @SerializedName("detected_mood") val detectedMood: String? = null
+    @SerializedName("detected_mood") val detectedMood: String? = null,
+    @SerializedName("sentiment_score") val sentimentScore: Float? = null,
+    @SerializedName("key_emotions") val keyEmotions: String? = null,
+    @SerializedName("message_id") val messageId: Int? = null
 )
 
 data class DeleteMessagesRequest(

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -94,7 +94,7 @@ class HomeChatViewModel @Inject constructor(
     fun sendMessage(text: String) {
         viewModelScope.launch {
             // 1. Tambahkan pesan pengguna ke history
-            chatRepository.addMessage(text, isUser = true)
+            val userMsg = chatRepository.addMessage(text, isUser = true)
 
             // 2. Sisipkan pesan sementara sebagai indikator mengetik
             val placeholder = chatRepository.addMessage(
@@ -110,7 +110,9 @@ class HomeChatViewModel @Inject constructor(
             // 4. Panggil API dengan batas waktu lebih lama agar server punya waktu
             //    yang cukup untuk merespons. Batas lama sebelumnya kadang terlalu
             //    singkat sehingga balasan AI tidak sempat diterima sepenuhnya.
-            val result = withTimeoutOrNull(30_000) { chatRepository.sendMessage(text) }
+            val result = withTimeoutOrNull(30_000) {
+                chatRepository.sendMessage(text, userMsg.id)
+            }
 
             // 5. Ganti pesan placeholder dengan hasil atau pesan kesalahan
             when (result) {

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
@@ -59,16 +59,17 @@ class HomeChatViewModelTest {
 
     @Test
     fun sendMessage_delegatesToRepository() = runTest {
-        whenever(repository.addMessage(any(), eq(true), eq(false))).thenReturn(ChatMessage(text="hi", isUser=true, userId = 1))
+        val userMsg = ChatMessage(id = 1, text="hi", isUser=true, userId = 1)
+        whenever(repository.addMessage(any(), eq(true), eq(false))).thenReturn(userMsg)
         whenever(repository.addMessage(any(), eq(false), eq(true))).thenReturn(ChatMessage(id=2, text="placeholder", isUser=false, isPlaceholder=true, userId = 1))
-        whenever(repository.sendMessage("hi")).thenReturn(
+        whenever(repository.sendMessage("hi", userMsg.id)).thenReturn(
             Result.Success(AiChatResponse("hello", "happy"))
         )
         viewModel.sendMessage("hi")
         advanceUntilIdle()
         verify(repository).addMessage("hi", true, false)
         verify(repository).addMessage("Sedang mengetik jawaban...", false, true)
-        verify(repository).sendMessage("hi")
+        verify(repository).sendMessage("hi", userMsg.id)
         verify(repository).updateMessageWithReply(2, "hello", "happy")
     }
 

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -90,6 +90,7 @@ async def chat_with_ai(
 
     # Removed artificial delay to improve responsiveness.
     return schemas.ChatResponse(
+        message_id=created_user_msg.id,
         reply_text=reply,
         sentiment_score=analysis_result.get("sentiment_score") if analysis_result else None,
         key_emotions=analysis_result.get("key_emotions") if analysis_result else None,
@@ -151,6 +152,7 @@ async def create_message(
     # The simple message endpoint does not store AI responses
 
     return schemas.ChatResponse(
+        message_id=created_msg.id,
         reply_text=reply,
         sentiment_score=analysis_result.get("sentiment_score") if analysis_result else None,
         key_emotions=analysis_result.get("key_emotions") if analysis_result else None,
@@ -198,9 +200,11 @@ async def prompt_chat(
         is_user=False,
         timestamp=now_ts,
     )
-    crud.chat_message.create_with_owner(db, obj_in=ai_msg, owner_id=current_user.id)
+    created_ai_msg = crud.chat_message.create_with_owner(
+        db, obj_in=ai_msg, owner_id=current_user.id
+    )
 
-    return schemas.ChatResponse(reply_text=reply)
+    return schemas.ChatResponse(message_id=created_ai_msg.id, reply_text=reply)
 
 
 @router.get(

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -4,6 +4,7 @@ class ChatRequest(BaseModel):
     message: str = Field(..., description="Message from the user")
 
 class ChatResponse(BaseModel):
+    message_id: int = Field(..., description="ID of the created message")
     reply_text: str = Field(..., description="Assistant reply text")
     sentiment_score: float | None = Field(
         None, description="Sentiment score for the reply"

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -132,6 +132,7 @@ def test_chat_sentiment_response(client, monkeypatch):
     resp = client.post("/api/v1/chat/", json={"message": "hello"}, headers=headers)
     assert resp.status_code == 200
     data = resp.json()
+    assert data["message_id"] > 0
     assert data["reply_text"] == "hi"
     assert data["sentiment_score"] == 0.5
     assert data["key_emotions"] == "happy"
@@ -167,6 +168,7 @@ def test_message_post_handler(client, monkeypatch):
     )
     assert resp.status_code == 200
     data = resp.json()
+    assert data["message_id"] > 0
     assert data["reply_text"] == "reply"
     assert data["sentiment_score"] == 0.2
     assert data["key_emotions"] == "calm"
@@ -220,7 +222,9 @@ def test_prompt_endpoint_rate_limit(client, monkeypatch):
 
     resp = client.post("/api/v1/chat/prompt", headers=headers)
     assert resp.status_code == 200
-    assert resp.json()["reply_text"] == "hey?"
+    data = resp.json()
+    assert data["reply_text"] == "hey?"
+    assert data["message_id"] > 0
 
     second = client.post("/api/v1/chat/prompt", headers=headers)
     assert second.status_code == 429


### PR DESCRIPTION
## Summary
- include `message_id` in backend ChatResponse
- mark sent messages as synced in ChatRepository
- add new fields to `AiChatResponse`
- update HomeChatViewModel to pass local id
- skip synced entries in syncPendingMessages
- adjust backend tests for new schema

## Testing
- `pip install -r backend/requirements.txt pytest`
- `pytest -q`
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6854c684c4a08324ae6ee9665414b564