### PR TITLE
Align chat endpoint URL

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
@@ -12,7 +12,7 @@ import retrofit2.http.GET
 import retrofit2.http.HTTP
 
 interface ChatApiService {
-    @POST("api/v1/chat")
+    @POST("api/v1/chat/")
     suspend fun sendMessage(@Body request: ChatRequest): Response<AiChatResponse>
 
     @GET("api/v1/chat/messages")


### PR DESCRIPTION
## Summary
- include trailing slash in ChatApiService `sendMessage` endpoint so the URL matches backend routing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ca1a2e6883248e66d008ee8260d5