### PR TITLE
Fix duplicate AI reply loop

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
@@ -35,7 +35,8 @@ data class AiChatResponse(
     @SerializedName("detected_mood") val detectedMood: String? = null,
     @SerializedName("sentiment_score") val sentimentScore: Float? = null,
     @SerializedName("key_emotions") val keyEmotions: String? = null,
-    @SerializedName("message_id") val messageId: Int? = null
+    @SerializedName("message_id") val messageId: Int? = null,
+    @SerializedName("ai_message_id") val replyId: Int? = null
 )
 
 data class DeleteMessagesRequest(

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -91,7 +91,8 @@ class ChatRepository @Inject constructor(
         newText: String,
         sentimentScore: Float? = null,
         keyEmotions: String? = null,
-        detectedMood: String? = null
+        detectedMood: String? = null,
+        remoteId: Int? = null
     ) {
         val uid = userPreferencesRepository.userId.first() ?: return
         val existing = chatMessageDao.getMessageById(id, uid) ?: return
@@ -100,7 +101,9 @@ class ChatRepository @Inject constructor(
             isPlaceholder = false,
             sentimentScore = sentimentScore,
             keyEmotions = keyEmotions,
-            detectedMood = detectedMood
+            detectedMood = detectedMood,
+            remoteId = remoteId ?: existing.remoteId,
+            isSynced = remoteId != null || existing.isSynced
         )
         chatMessageDao.updateMessage(updated)
     }
@@ -172,8 +175,13 @@ class ChatRepository @Inject constructor(
         }
     }
 
-    suspend fun updateMessageWithReply(id: Int, replyText: String, detectedMood: String? = null) {
-        replaceMessage(id, replyText, detectedMood = detectedMood)
+    suspend fun updateMessageWithReply(
+        id: Int,
+        replyText: String,
+        detectedMood: String? = null,
+        remoteId: Int? = null
+    ) {
+        replaceMessage(id, replyText, detectedMood = detectedMood, remoteId = remoteId)
     }
 
     suspend fun syncPendingMessages(): Result<Unit> {

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -119,9 +119,10 @@ class HomeChatViewModel @Inject constructor(
                 is Result.Success -> {
                     val response = result.data
                     chatRepository.updateMessageWithReply(
-                        placeholder.id,
-                        response.replyText,
-                        response.detectedMood
+                        id = placeholder.id,
+                        replyText = response.replyText,
+                        detectedMood = response.detectedMood,
+                        remoteId = response.replyId
                     )
                 }
                 is Result.Error, null -> {

--- a/app/src/test/java/com/psy/deardiary/data/repository/ChatRepositoryTest.kt
+++ b/app/src/test/java/com/psy/deardiary/data/repository/ChatRepositoryTest.kt
@@ -49,7 +49,9 @@ class ChatRepositoryTest {
 
     @Test
     fun fetchReplySuccess_returnsSuccess() = runTest {
-        whenever(api.sendMessage(any())).thenReturn(Response.success(AiChatResponse("hi")))
+        whenever(api.sendMessage(any())).thenReturn(
+            Response.success(AiChatResponse("hi", replyId = 1))
+        )
 
         val result = repository.fetchReply("hello")
 

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
@@ -63,14 +63,14 @@ class HomeChatViewModelTest {
         whenever(repository.addMessage(any(), eq(true), eq(false))).thenReturn(userMsg)
         whenever(repository.addMessage(any(), eq(false), eq(true))).thenReturn(ChatMessage(id=2, text="placeholder", isUser=false, isPlaceholder=true, userId = 1))
         whenever(repository.sendMessage("hi", userMsg.id)).thenReturn(
-            Result.Success(AiChatResponse("hello", "happy"))
+            Result.Success(AiChatResponse("hello", "happy", replyId = 3))
         )
         viewModel.sendMessage("hi")
         advanceUntilIdle()
         verify(repository).addMessage("hi", true, false)
         verify(repository).addMessage("Sedang mengetik jawaban...", false, true)
         verify(repository).sendMessage("hi", userMsg.id)
-        verify(repository).updateMessageWithReply(2, "hello", "happy")
+        verify(repository).updateMessageWithReply(2, "hello", "happy", 3)
     }
 
     @Test

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -57,7 +57,9 @@ async def chat_with_ai(
         is_user=False,
         timestamp=int(asyncio.get_event_loop().time() * 1000),
     )
-    crud.chat_message.create_with_owner(db, obj_in=ai_msg, owner_id=current_user.id)
+    created_ai_msg = crud.chat_message.create_with_owner(
+        db, obj_in=ai_msg, owner_id=current_user.id
+    )
 
     # Classify user's mood using the heuristic classifier
     detected_mood = detect_mood(chat_in.message)
@@ -80,6 +82,7 @@ async def chat_with_ai(
     # Removed artificial delay to improve responsiveness.
     return schemas.ChatResponse(
         message_id=created_user_msg.id,
+        ai_message_id=created_ai_msg.id,
         reply_text=reply,
         sentiment_score=None,
         key_emotions=None,
@@ -142,6 +145,7 @@ async def create_message(
 
     return schemas.ChatResponse(
         message_id=created_msg.id,
+        ai_message_id=None,
         reply_text=reply,
         sentiment_score=analysis_result.get("sentiment_score") if analysis_result else None,
         key_emotions=analysis_result.get("key_emotions") if analysis_result else None,
@@ -193,7 +197,11 @@ async def prompt_chat(
         db, obj_in=ai_msg, owner_id=current_user.id
     )
 
-    return schemas.ChatResponse(message_id=created_ai_msg.id, reply_text=reply)
+    return schemas.ChatResponse(
+        message_id=created_ai_msg.id,
+        ai_message_id=created_ai_msg.id,
+        reply_text=reply,
+    )
 
 
 @router.get(

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -5,6 +5,9 @@ class ChatRequest(BaseModel):
 
 class ChatResponse(BaseModel):
     message_id: int = Field(..., description="ID of the created message")
+    ai_message_id: int | None = Field(
+        None, description="ID of the AI-generated reply message"
+    )
     reply_text: str = Field(..., description="Assistant reply text")
     sentiment_score: float | None = Field(
         None, description="Sentiment score for the reply"

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -133,6 +133,7 @@ def test_chat_sentiment_response(client, monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["message_id"] > 0
+    assert data["ai_message_id"] > 0
     assert data["reply_text"] == "hi"
     # Sentiment analysis now runs asynchronously so values are not returned immediately
     assert data["sentiment_score"] is None
@@ -170,6 +171,7 @@ def test_message_post_handler(client, monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["message_id"] > 0
+    assert data["ai_message_id"] is None
     assert data["reply_text"] == "reply"
     assert data["sentiment_score"] == 0.2
     assert data["key_emotions"] == "calm"
@@ -226,6 +228,7 @@ def test_prompt_endpoint_rate_limit(client, monkeypatch):
     data = resp.json()
     assert data["reply_text"] == "hey?"
     assert data["message_id"] > 0
+    assert data["ai_message_id"] == data["message_id"]
 
     second = client.post("/api/v1/chat/prompt", headers=headers)
     assert second.status_code == 429


### PR DESCRIPTION
## Summary
- include AI message id in chat response schema
- return this id from chat endpoints
- expose new field in Android DTO
- mark AI messages as synced when saving reply
- adapt unit tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6854cdcbed9c83248edf24f9541cef26