### PR TITLE
Show sentiment info in chat

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,8 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.ui.test.junit4)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.ui.test.junit4) // For Compose UI tests

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -261,7 +261,7 @@ private fun ChatInputBar(onSend: (String) -> Unit) {
 
 
 @Composable
-private fun ChatBubble(
+internal fun ChatBubble(
     message: ChatMessage,
     isSelected: Boolean = false,
     modifier: Modifier = Modifier
@@ -304,6 +304,38 @@ private fun ChatBubble(
             } else {
                 Column(modifier = Modifier.padding(8.dp)) {
                     Text(text = message.text)
+                    if (message.sentimentScore != null || message.keyEmotions != null) {
+                        Spacer(Modifier.height(4.dp))
+                        val score = message.sentimentScore
+                        val (icon, color) = when {
+                            score == null -> Pair(Icons.Outlined.SentimentNeutral, MaterialTheme.colorScheme.onSurfaceVariant)
+                            score >= 0f -> Pair(Icons.Outlined.Mood, Color(0xFF2E7D32))
+                            else -> Pair(Icons.Outlined.MoodBad, Color(0xFFC62828))
+                        }
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = icon,
+                                contentDescription = null,
+                                tint = color,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            score?.let {
+                                Text(
+                                    text = String.format("%.1f", it),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = color,
+                                    modifier = Modifier.padding(start = 4.dp)
+                                )
+                            }
+                            message.keyEmotions?.let {
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    modifier = Modifier.padding(start = 8.dp)
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/app/src/test/java/com/psy/deardiary/features/home/ChatBubbleTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/ChatBubbleTest.kt
@@ -1,0 +1,33 @@
+package com.psy.deardiary.features.home
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.psy.deardiary.data.model.ChatMessage
+import org.junit.Rule
+import org.junit.Test
+
+class ChatBubbleTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun showsSentimentInfo_whenPresent() {
+        val msg = ChatMessage(
+            id = 1,
+            text = "hi",
+            isUser = false,
+            userId = 1,
+            sentimentScore = 0.6f,
+            keyEmotions = "joy"
+        )
+        composeTestRule.setContent {
+            MaterialTheme {
+                ChatBubble(message = msg)
+            }
+        }
+        composeTestRule.onNodeWithText("joy").assertIsDisplayed()
+        composeTestRule.onNodeWithText("0.6").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Summary
- expose latestEmotions in `ChatRepository`
- refresh messages after sync to pick up sentiment data
- display sentiment score and emotions in `ChatBubble`
- add Compose UI test for sentiment display
- include Compose test dependencies

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e895abb883248e03589ada23bf3a