### PR TITLE
Use settings.AI_MODEL in sentiment analyzer

### DIFF
--- a/backend/app/services/sentiment_analyzer.py
+++ b/backend/app/services/sentiment_analyzer.py
@@ -29,7 +29,7 @@ async def analyze_sentiment_with_ai(text: str) -> dict | None:
     # Model yang akan digunakan (contoh: Google Gemini Flash)
     # Anda bisa menggantinya dengan model lain yang tersedia di OpenRouter
     body = {
-        "model": "google/gemini-flash-1.5",
+        "model": settings.AI_MODEL,
         "messages": [
             {"role": "user", "content": prompt}
         ],


### PR DESCRIPTION
## Summary
- use model from configuration in sentiment analyzer service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ed35b6c48324a16e52af0b21c557