### PR TITLE
Add journal template propagation

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
@@ -33,6 +33,7 @@ data class ChatMessageCreateRequest(
 data class AiChatResponse(
     @SerializedName("action") val action: String,
     @SerializedName("text_response") val textResponse: String,
+    @SerializedName("journal_template") val journalTemplate: String? = null,
     @SerializedName("detected_mood") val detectedMood: String? = null,
     @SerializedName("sentiment_score") val sentimentScore: Float? = null,
     @SerializedName("key_emotions") val keyEmotions: String? = null,

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -36,6 +36,7 @@ class HomeChatViewModel @Inject constructor(
 
     private val _pendingAction = MutableStateFlow<String?>(null)
     val pendingAction = _pendingAction.asStateFlow()
+    val journalTemplate = chatRepository.journalTemplate
 
     private val _selectedIds = MutableStateFlow<Set<Int>>(emptySet())
     val selectedIds = _selectedIds.asStateFlow()
@@ -153,5 +154,6 @@ class HomeChatViewModel @Inject constructor(
 
     fun consumeAction() {
         _pendingAction.value = null
+        chatRepository.clearJournalTemplate()
     }
 }

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -45,6 +45,7 @@ fun HomeScreen(
     onNavigateToSettings: () -> Unit,
     onNavigateToCrisisSupport: () -> Unit,
     onNavigateToEditor: () -> Unit,
+    onNavigateToEditorWithPrompt: (String) -> Unit,
     mainViewModel: com.psy.deardiary.features.main.MainViewModel,
     viewModel: HomeViewModel = hiltViewModel(),
     chatViewModel: HomeChatViewModel = hiltViewModel()
@@ -62,11 +63,15 @@ fun HomeScreen(
     var showBreathing by remember { mutableStateOf(false) }
 
     val pendingAction by chatViewModel.pendingAction.collectAsState()
+    val journalTemplate by chatViewModel.journalTemplate.collectAsState()
 
     LaunchedEffect(pendingAction) {
         when (pendingAction) {
             "suggest_breathing_exercise" -> showBreathing = true
-            "open_journal_editor" -> onNavigateToEditor()
+            "open_journal_editor" -> {
+                journalTemplate?.let { onNavigateToEditorWithPrompt(it) }
+                    ?: onNavigateToEditor()
+            }
             "show_crisis_contact" -> onNavigateToCrisisSupport()
         }
         if (pendingAction != null) chatViewModel.consumeAction()

--- a/app/src/main/java/com/psy/deardiary/features/main/MainScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/main/MainScreen.kt
@@ -88,6 +88,10 @@ fun MainScreen(
                     onNavigateToSettings = { mainNavController.navigate(Screen.Settings.route) },
                     onNavigateToCrisisSupport = { mainNavController.navigate(Screen.CrisisSupport.route) },
                     onNavigateToEditor = { mainNavController.navigate(Screen.Editor.createRoute(null)) },
+                    onNavigateToEditorWithPrompt = { prompt ->
+                        val encodedPrompt = URLEncoder.encode(prompt, "UTF-8")
+                        mainNavController.navigate(Screen.Editor.createRoute(prompt = encodedPrompt))
+                    },
                     mainViewModel = mainViewModel
                 )
             }

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -45,6 +45,7 @@ async def chat_with_ai(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="AI service error")
     action = reply["action"]
     reply_text = reply["text_response"]
+    journal_template = reply.get("journal_template")
     # Persist conversation
     user_msg = schemas.ChatMessageCreate(
         text=chat_in.message,
@@ -97,6 +98,7 @@ async def chat_with_ai(
         issue_type=analysis.get("issue_type") if analysis else None,
         recommended_technique=analysis.get("technique") if analysis else None,
         tone=analysis.get("tone") if analysis else None,
+        journal_template=journal_template,
     )
 
 
@@ -152,6 +154,7 @@ async def create_message(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="AI service error")
     action = reply["action"]
     reply_text = reply["text_response"]
+    journal_template = reply.get("journal_template")
 
     # The simple message endpoint does not store AI responses
 
@@ -166,6 +169,7 @@ async def create_message(
         issue_type=None,
         recommended_technique=None,
         tone=None,
+        journal_template=journal_template,
     )
 
 
@@ -205,6 +209,7 @@ async def prompt_chat(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="AI service error")
     action = reply["action"]
     reply_text = reply["text_response"]
+    journal_template = reply.get("journal_template")
 
     ai_msg = schemas.ChatMessageCreate(
         text=reply_text,
@@ -220,6 +225,7 @@ async def prompt_chat(
         ai_message_id=created_ai_msg.id,
         action=action,
         text_response=reply_text,
+        journal_template=journal_template,
     )
 
 

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -29,3 +29,6 @@ class ChatResponse(BaseModel):
     tone: str | None = Field(
         None, description="Estimated user tone"
     )
+    journal_template: str | None = Field(
+        None, description="Suggested journal template when opening the editor"
+    )

--- a/backend/app/services/chat_responder.py
+++ b/backend/app/services/chat_responder.py
@@ -70,14 +70,23 @@ async def get_ai_reply(message: str, context: str = "", relationship_level: int 
             parsed = json.loads(reply)
             action = parsed.get("action", Action.balas_teks.value)
             text = parsed.get("text_response", "")
+            journal_template = (
+                parsed.get("journal_template")
+                if action == Action.open_journal_editor.value
+                else None
+            )
         except json.JSONDecodeError:
             action = Action.balas_teks.value
             text = reply
+            journal_template = None
 
         if len(text) > MAX_REPLY_LENGTH:
             text = text[:MAX_REPLY_LENGTH]
 
-        return {"action": action, "text_response": text}
+        result = {"action": action, "text_response": text}
+        if journal_template is not None:
+            result["journal_template"] = journal_template
+        return result
 
     # --- BLOK EXCEPT YANG DISEMPURNAKAN ---
 


### PR DESCRIPTION
## Summary
- support optional `journal_template` in `ChatResponse`
- parse template in AI responder and return via endpoints
- include journalTemplate in Android DTOs
- expose journalTemplate flow from `ChatRepository`
- update `HomeChatViewModel` and `HomeScreen` to open editor with prompt
- adjust `MainScreen` for new `HomeScreen` parameter

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ee2fa9fc8324b5ee8c8d6db838dd