### PR TITLE
Fix icon imports

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -17,6 +17,9 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.CrisisAlert
 import androidx.compose.material.icons.outlined.EmojiEmotions
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.SentimentNeutral
+import androidx.compose.material.icons.outlined.Mood
+import androidx.compose.material.icons.outlined.MoodBad
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment


### PR DESCRIPTION
## Summary
- import mood-related Material icons in `HomeScreen`

## Testing
- `gradle test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68550b61a6a48324b7a38d9961a62e38