### PR TITLE
Add semantic embeddings table

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Backend menggunakan FastAPI dan SQLAlchemy. Skema database dikelola melalui Alem
    ```
    Setelah itu jalankan perintah `upgrade` di atas.
 
+   Setelah menarik revisi 0007, jalankan kembali perintah di atas agar tabel `semantic_embeddings` dibuat.
+
 4. Mulai server pengembangan:
 
    ```bash

--- a/backend/alembic/versions/0007_create_semantic_embeddings.py
+++ b/backend/alembic/versions/0007_create_semantic_embeddings.py
@@ -1,0 +1,22 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0007'
+down_revision = '0006'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'semantic_embeddings',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('owner_id', sa.Integer(), sa.ForeignKey('users.id'), index=True),
+        sa.Column('source_type', sa.String(), nullable=False),
+        sa.Column('source_id', sa.Integer(), nullable=False),
+        sa.Column('embedding', sa.JSON(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table('semantic_embeddings')


### PR DESCRIPTION
## Summary
- create migration 0007 for new semantic_embeddings table
- remind users to run Alembic upgrade in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550f5ac7c88324a8d8b70a472b35d0