### PR TITLE
Update mbti property in chat context

### DIFF
--- a/backend/app/services/chat_context.py
+++ b/backend/app/services/chat_context.py
@@ -38,9 +38,8 @@ def build_chat_context(db: Session, user: models.User, text: str | None = None) 
         info_parts.append(user.name)
     if user.bio:
         info_parts.append(user.bio)
-    mbti = getattr(user, "mbti", None)
-    if mbti:
-        info_parts.append(f"MBTI: {mbti}")
+    if user.mbti_type:
+        info_parts.append(f"MBTI: {user.mbti_type}")
     if info_parts:
         sections.append("User info: " + ", ".join(info_parts))
 


### PR DESCRIPTION
## Summary
- access the user's MBTI directly via `mbti_type` when building chat context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855106f43488324b593c42d8651bb9f