### PR TITLE
Handle analysis separately in AI replies

### DIFF
--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -33,13 +33,12 @@ async def chat_with_ai(
     logic so responses remain snappy."""
     analysis = await analyze_message(chat_in.message)
     context = build_chat_context(db, current_user, chat_in.message)
-    if analysis:
-        context += "\nAnalysis: " + json.dumps(analysis, ensure_ascii=False)
 
     reply = await get_ai_reply(
         chat_in.message,
         context=context,
         relationship_level=current_user.relationship_level,
+        analysis=analysis,
     )
     if reply is None:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="AI service error")

--- a/backend/tests/test_chat_responder.py
+++ b/backend/tests/test_chat_responder.py
@@ -1,0 +1,26 @@
+import json
+import asyncio
+from app.services.chat_responder import get_ai_reply
+
+def test_get_ai_reply_includes_analysis(monkeypatch):
+    captured = {}
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def post(self, url, headers=None, json=None, timeout=None):
+            captured['messages'] = json['messages']
+            class Resp:
+                def raise_for_status(self):
+                    pass
+                def json(self):
+                    return {"choices": [{"message": {"content": '{"action":"balas_teks","text_response":"ok"}'}}]}
+            return Resp()
+
+    monkeypatch.setattr("app.services.chat_responder.httpx.AsyncClient", DummyClient)
+    analysis = {"issue_type": "stress"}
+    reply = asyncio.run(get_ai_reply("hi", analysis=analysis))
+    assert reply == {"action": "balas_teks", "text_response": "ok"}
+    assert captured['messages'][0]['content'] == json.dumps(analysis, ensure_ascii=False)

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -60,7 +60,7 @@ def register_and_login(client, email="user@example.com", password="pass"):
 def test_chat_context_assembly(client, monkeypatch):
     captured = {}
 
-    async def fake_reply(message: str, context: str = "", relationship_level: int = 0):
+    async def fake_reply(message: str, context: str = "", relationship_level: int = 0, analysis=None):
         captured["context"] = context
         return {"action": "balas_teks", "text_response": "ok"}
 
@@ -114,7 +114,7 @@ def test_chat_context_assembly(client, monkeypatch):
 def test_prompt_context_assembly(client, monkeypatch):
     captured = {}
 
-    async def fake_reply(message: str, context: str = "", relationship_level: int = 0):
+    async def fake_reply(message: str, context: str = "", relationship_level: int = 0, analysis=None):
         captured["context"] = context
         return {"action": "balas_teks", "text_response": "ok"}
 


### PR DESCRIPTION
## Summary
- allow `get_ai_reply` to receive an `analysis` dictionary
- insert the analysis as a system message before other prompts
- pass analysis through `chat_with_ai`
- adjust existing tests and add new test coverage

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551dcce6d483249d47ab762144c8a5