### PR TITLE
Disable sentiment icons in chat bubble

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -17,9 +17,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.CrisisAlert
 import androidx.compose.material.icons.outlined.EmojiEmotions
 import androidx.compose.material.icons.outlined.Settings
-import androidx.compose.material.icons.outlined.SentimentNeutral
-import androidx.compose.material.icons.outlined.Mood
-import androidx.compose.material.icons.outlined.MoodBad
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -312,6 +309,8 @@ internal fun ChatBubble(
             } else {
                 Column(modifier = Modifier.padding(8.dp)) {
                     Text(text = message.text)
+                    // Sentiment display disabled but data kept for statistics
+                    /*
                     if (message.sentimentScore != null || message.keyEmotions != null) {
                         Spacer(Modifier.height(4.dp))
                         val score = message.sentimentScore
@@ -344,6 +343,7 @@ internal fun ChatBubble(
                             }
                         }
                     }
+                    */
                 }
             }
         }


### PR DESCRIPTION
## Summary
- remove sentiment icon imports
- disable display of sentiment scores in ChatBubble

## Testing
- `pip install -r backend/requirements.txt pytest`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685536321a748324b13b3c854c6954df