### PR TITLE
Integrate chat mood logs into Growth stats

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/EmotionLogDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/EmotionLogDtos.kt
@@ -1,0 +1,13 @@
+package com.psy.deardiary.data.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class EmotionLogResponse(
+    val id: Int,
+    val timestamp: Long,
+    @SerializedName("detected_mood") val detectedMood: String?,
+    @SerializedName("source_text") val sourceText: String,
+    @SerializedName("source_feature") val sourceFeature: String,
+    @SerializedName("sentiment_score") val sentimentScore: Float?,
+    @SerializedName("key_emotions_detected") val keyEmotionsDetected: List<String>?
+)

--- a/app/src/main/java/com/psy/deardiary/data/dto/EmotionLogMappers.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/EmotionLogMappers.kt
@@ -1,0 +1,15 @@
+package com.psy.deardiary.data.dto
+
+import com.psy.deardiary.data.model.EmotionLog
+
+fun EmotionLogResponse.toEmotionLog(): EmotionLog {
+    return EmotionLog(
+        id = this.id,
+        timestamp = this.timestamp,
+        detectedMood = this.detectedMood,
+        sourceText = this.sourceText,
+        sourceFeature = this.sourceFeature,
+        sentimentScore = this.sentimentScore,
+        keyEmotionsDetected = this.keyEmotionsDetected
+    )
+}

--- a/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
+++ b/app/src/main/java/com/psy/deardiary/data/local/ChatMessageDao.kt
@@ -12,6 +12,9 @@ interface ChatMessageDao {
     @Query("SELECT * FROM chat_messages WHERE userId = :userId ORDER BY timestamp ASC")
     fun getAllMessages(userId: Int): Flow<List<ChatMessage>>
 
+    @Query("SELECT * FROM chat_messages WHERE userId = :userId")
+    suspend fun getAllMessagesOnce(userId: Int): List<ChatMessage>
+
     @Query("SELECT * FROM chat_messages WHERE isSynced = 0 AND userId = :userId")
     suspend fun getUnsyncedMessages(userId: Int): List<ChatMessage>
 

--- a/app/src/main/java/com/psy/deardiary/data/model/EmotionLog.kt
+++ b/app/src/main/java/com/psy/deardiary/data/model/EmotionLog.kt
@@ -1,0 +1,11 @@
+package com.psy.deardiary.data.model
+
+data class EmotionLog(
+    val id: Int,
+    val timestamp: Long,
+    val detectedMood: String?,
+    val sourceText: String,
+    val sourceFeature: String,
+    val sentimentScore: Float?,
+    val keyEmotionsDetected: List<String>?
+)

--- a/app/src/main/java/com/psy/deardiary/data/network/EmotionLogApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/EmotionLogApiService.kt
@@ -1,0 +1,14 @@
+package com.psy.deardiary.data.network
+
+import com.psy.deardiary.data.dto.EmotionLogResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface EmotionLogApiService {
+    @GET("api/v1/emotion")
+    suspend fun getEmotionLogs(
+        @Query("skip") skip: Int = 0,
+        @Query("limit") limit: Int = 100
+    ): Response<List<EmotionLogResponse>>
+}

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -278,4 +278,9 @@ class ChatRepository @Inject constructor(
     fun clearJournalTemplate() {
         _journalTemplate.value = null
     }
+
+    suspend fun getAllMessagesOnce(): List<ChatMessage> {
+        val uid = userPreferencesRepository.userId.first() ?: 0
+        return withContext(Dispatchers.IO) { chatMessageDao.getAllMessagesOnce(uid) }
+    }
 }

--- a/app/src/main/java/com/psy/deardiary/data/repository/EmotionLogRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/EmotionLogRepository.kt
@@ -1,0 +1,39 @@
+package com.psy.deardiary.data.repository
+
+import com.psy.deardiary.data.dto.toEmotionLog
+import com.psy.deardiary.data.network.EmotionLogApiService
+import com.psy.deardiary.data.model.EmotionLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EmotionLogRepository @Inject constructor(
+    private val emotionLogApiService: EmotionLogApiService
+) {
+    private val _logs = MutableStateFlow<List<EmotionLog>>(emptyList())
+    val logs = _logs.asStateFlow()
+
+    suspend fun refreshEmotionLogs(): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = emotionLogApiService.getEmotionLogs()
+                if (response.isSuccessful && response.body() != null) {
+                    _logs.value = response.body()!!.map { it.toEmotionLog() }
+                    Result.Success(Unit)
+                } else {
+                    Result.Error(response.message())
+                }
+            } catch (e: HttpException) {
+                Result.Error("Server error: ${e.code()}")
+            } catch (e: IOException) {
+                Result.Error("Tidak dapat terhubung ke server.")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/psy/deardiary/di/AppModule.kt
+++ b/app/src/main/java/com/psy/deardiary/di/AppModule.kt
@@ -9,11 +9,13 @@ import com.psy.deardiary.data.local.ChatMessageDao
 import com.psy.deardiary.data.network.AuthApiService
 import com.psy.deardiary.data.network.AuthInterceptor
 import com.psy.deardiary.data.network.ChatApiService
+import com.psy.deardiary.data.network.EmotionLogApiService
 import com.psy.deardiary.data.network.JournalApiService
 import com.psy.deardiary.data.network.FeedApiService
 import com.psy.deardiary.data.network.UserApiService
 import com.psy.deardiary.data.repository.AuthRepository
 import com.psy.deardiary.data.repository.ChatRepository
+import com.psy.deardiary.data.repository.EmotionLogRepository
 import com.psy.deardiary.data.repository.JournalRepository
 import com.psy.deardiary.data.repository.FeedRepository
 import com.psy.deardiary.data.repository.UserRepository
@@ -116,6 +118,12 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideEmotionLogApiService(retrofit: Retrofit): EmotionLogApiService {
+        return retrofit.create(EmotionLogApiService::class.java)
+    }
+
+    @Provides
+    @Singleton
     fun provideFeedApiService(retrofit: Retrofit): FeedApiService {
         return retrofit.create(FeedApiService::class.java)
     }
@@ -153,6 +161,14 @@ object AppModule {
         userPreferencesRepository: UserPreferencesRepository
     ): ChatRepository {
         return ChatRepository(chatApiService, chatMessageDao, userPreferencesRepository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideEmotionLogRepository(
+        emotionLogApiService: EmotionLogApiService
+    ): EmotionLogRepository {
+        return EmotionLogRepository(emotionLogApiService)
     }
 
     @Provides


### PR DESCRIPTION
## Summary
- fetch emotion logs from API via new `EmotionLogRepository`
- expose new `EmotionLogApiService`
- add DTO/model mapping for emotion logs
- expose chat message list helper
- update DI for new repository/service
- include chat and emotion log moods in `GrowthViewModel`

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6855372706d08324ae28905b289e2d5c