### PR TITLE
Fix unresolved import

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.tryLock
 import javax.inject.Inject
 
 @HiltViewModel


### PR DESCRIPTION
## Summary
- remove invalid `tryLock` import in `HomeChatViewModel`

## Testing
- `pytest -q backend/tests/test_crud_journal.py::test_create_journal` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68553aa956748324af32e853ca7a5931