### PR TITLE
Add conversation planner service

### DIFF
--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -17,3 +17,4 @@ from .emotion_log import (
     EmotionLogCreate,
     EmotionLogUpdate,
 )
+from .conversation import ConversationPlan

--- a/backend/app/schemas/conversation.py
+++ b/backend/app/schemas/conversation.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel, Field
+
+class ConversationPlan(BaseModel):
+    """Technique chosen for guiding the next assistant reply."""
+    technique: str = Field(..., description="Conversation technique to apply")

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -2,3 +2,4 @@
 
 from .chat_context import build_chat_context
 from .message_analyzer import analyze_message
+from .conversation_planner import plan_conversation_strategy

--- a/backend/app/services/conversation_planner.py
+++ b/backend/app/services/conversation_planner.py
@@ -1,0 +1,48 @@
+import json
+import httpx
+
+from app.core.config import settings
+
+from app.schemas.conversation import ConversationPlan
+
+async def plan_conversation_strategy(context: str, user_message: str) -> ConversationPlan | None:
+    """Request a conversation technique suggestion from the AI service."""
+    prompt = f"""
+You are the 'director' persona guiding how the assistant should reply next.
+Given the current conversation context and the latest user message, choose the most suitable communication technique the assistant should use.
+Respond only with raw JSON containing a single key named \"technique\".
+
+Context:\n{context}
+
+User message:\n{user_message}
+"""
+
+    headers = {
+        "Authorization": f"Bearer {settings.AI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    body = {
+        "model": settings.AI_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "response_format": {"type": "json_object"},
+    }
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                url=settings.AI_API_URL,
+                headers=headers,
+                json=body,
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            content = data["choices"][0]["message"]["content"]
+            parsed = json.loads(content)
+            technique = parsed.get("technique")
+            if not isinstance(technique, str):
+                raise ValueError("Invalid technique")
+            return ConversationPlan(technique=technique)
+    except (httpx.RequestError, httpx.HTTPStatusError, json.JSONDecodeError, KeyError, ValueError) as e:
+        print(f"Error calling conversation planner: {e}")
+        return None

--- a/backend/tests/test_conversation_planner.py
+++ b/backend/tests/test_conversation_planner.py
@@ -1,0 +1,50 @@
+import os
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("AI_API_KEY", "test")
+os.environ.setdefault("AI_API_URL", "http://test")
+os.environ.setdefault("AI_MODEL", "test-model")
+import sys
+import asyncio
+import httpx
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.conversation_planner import plan_conversation_strategy
+
+
+def test_plan_conversation_strategy_parses_json(monkeypatch):
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def post(self, url, headers=None, json=None, timeout=None):
+            class Resp:
+                def raise_for_status(self):
+                    pass
+                def json(self):
+                    return {"choices": [{"message": {"content": '{"technique":"reflection"}'}}]}
+            return Resp()
+
+    monkeypatch.setattr("app.services.conversation_planner.httpx.AsyncClient", DummyClient)
+    plan = asyncio.run(plan_conversation_strategy("ctx", "hi"))
+    assert plan is not None
+    assert plan.technique == "reflection"
+
+
+def test_plan_conversation_strategy_api_error(monkeypatch):
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def post(self, url, headers=None, json=None, timeout=None):
+            class Resp:
+                def raise_for_status(self):
+                    raise httpx.HTTPStatusError("bad", request=None, response=None)
+            return Resp()
+
+    monkeypatch.setattr("app.services.conversation_planner.httpx.AsyncClient", DummyClient)
+    plan = asyncio.run(plan_conversation_strategy("ctx", "hi"))
+    assert plan is None


### PR DESCRIPTION
## Summary
- add `ConversationPlan` schema
- implement `plan_conversation_strategy` service
- export new utilities
- add unit tests for conversation planner

## Testing
- `pytest backend/tests/test_conversation_planner.py -q`
- `pytest -q` *(fails: OperationalError in websocket test)*

------
https://chatgpt.com/codex/tasks/task_e_68556f0ccd6c8324bfd115d4d724ee2c