### PR TITLE
Add pure response generator

### DIFF
--- a/backend/app/schemas/conversation.py
+++ b/backend/app/schemas/conversation.py
@@ -3,3 +3,8 @@ from pydantic import BaseModel, Field
 class ConversationPlan(BaseModel):
     """Technique chosen for guiding the next assistant reply."""
     technique: str = Field(..., description="Conversation technique to apply")
+
+    @property
+    def technique_to_use(self) -> str:
+        """Alias property for the technique string."""
+        return self.technique

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -3,3 +3,4 @@
 from .chat_context import build_chat_context
 from .message_analyzer import analyze_message
 from .conversation_planner import plan_conversation_strategy
+from .response_generator import generate_pure_response

--- a/backend/app/services/response_generator.py
+++ b/backend/app/services/response_generator.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import httpx
+
+from app.core.config import settings
+from app.schemas.conversation import ConversationPlan
+
+
+async def generate_pure_response(plan: ConversationPlan, user_message: str) -> str:
+    """Generate a plain text reply applying the given conversation technique."""
+    technique = plan.technique_to_use
+    prompt = f"""
+You are the 'actor' persona executing the assistant's reply.
+Follow the director's instructions exactly and use this technique: {technique}.
+Respond directly to the user in Bahasa Indonesia without any JSON or formatting.
+
+User message:\n{user_message}
+"""
+
+    headers = {
+        "Authorization": f"Bearer {settings.AI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    body = {
+        "model": settings.AI_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                url=settings.AI_API_URL,
+                headers=headers,
+                json=body,
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data["choices"][0]["message"]["content"].strip()
+    except (httpx.RequestError, httpx.HTTPStatusError, KeyError) as e:
+        print(f"Error calling response generator: {e}")
+        return ""

--- a/backend/tests/test_response_generator.py
+++ b/backend/tests/test_response_generator.py
@@ -1,0 +1,44 @@
+import os
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("AI_API_KEY", "test")
+os.environ.setdefault("AI_API_URL", "http://test")
+os.environ.setdefault("AI_MODEL", "test-model")
+import sys
+import asyncio
+import httpx
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.schemas.conversation import ConversationPlan
+from app.services.response_generator import generate_pure_response
+
+
+def test_generate_pure_response_prompt(monkeypatch):
+    captured = {}
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, headers=None, json=None, timeout=None):
+            captured['json'] = json
+
+            class Resp:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"choices": [{"message": {"content": "reply"}}]}
+
+            return Resp()
+
+    monkeypatch.setattr("app.services.response_generator.httpx.AsyncClient", DummyClient)
+    plan = ConversationPlan(technique="mirroring")
+    result = asyncio.run(generate_pure_response(plan, "hi"))
+    assert result == "reply"
+    assert "mirroring" in captured['json']['messages'][0]['content']
+    assert 'response_format' not in captured['json']


### PR DESCRIPTION
## Summary
- implement new `generate_pure_response` service for a plain text reply
- expose the new service via `app.services`
- add alias `technique_to_use` on `ConversationPlan`
- test prompt construction for pure response generator

## Testing
- `pytest -q` *(fails: WebSocketDisconnect)*
- `pytest backend/tests/test_response_generator.py::test_generate_pure_response_prompt -q`

------
https://chatgpt.com/codex/tasks/task_e_685571658ab08324b010162d797d7050