### PR TITLE
Rename ChatResponse model

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
@@ -30,15 +30,10 @@ data class ChatMessageCreateRequest(
     @SerializedName("detected_mood") val detectedMood: String? = null
 )
 
-data class AiChatResponse(
-    @SerializedName("action") val action: String,
-    @SerializedName("text_response") val textResponse: String,
-    @SerializedName("journal_template") val journalTemplate: String? = null,
-    @SerializedName("detected_mood") val detectedMood: String? = null,
-    @SerializedName("sentiment_score") val sentimentScore: Float? = null,
-    @SerializedName("key_emotions") val keyEmotions: String? = null,
-    @SerializedName("message_id") val messageId: Int? = null,
-    @SerializedName("ai_message_id") val replyId: Int? = null
+data class FinalChatResponse(
+    @SerializedName("message_id") val messageId: Int,
+    @SerializedName("ai_message_id") val replyId: Int?,
+    @SerializedName("text_response") val textResponse: String
 )
 
 data class DeleteMessagesRequest(

--- a/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
+++ b/app/src/main/java/com/psy/deardiary/data/network/ChatApiService.kt
@@ -1,7 +1,7 @@
 package com.psy.deardiary.data.network
 
 import com.psy.deardiary.data.dto.ChatRequest
-import com.psy.deardiary.data.dto.AiChatResponse
+import com.psy.deardiary.data.dto.FinalChatResponse
 import com.psy.deardiary.data.dto.ChatMessageCreateRequest
 import com.psy.deardiary.data.dto.ChatMessageResponse
 import com.psy.deardiary.data.dto.DeleteMessagesRequest
@@ -13,7 +13,7 @@ import retrofit2.http.HTTP
 
 interface ChatApiService {
     @POST("api/v1/chat/")
-    suspend fun sendMessage(@Body request: ChatRequest): Response<AiChatResponse>
+    suspend fun sendMessage(@Body request: ChatRequest): Response<FinalChatResponse>
 
     @GET("api/v1/chat/messages")
     suspend fun getMessages(): Response<List<ChatMessageResponse>>
@@ -25,5 +25,5 @@ interface ChatApiService {
     suspend fun deleteMessages(@Body request: DeleteMessagesRequest): Response<Unit>
 
     @POST("api/v1/chat/prompt")
-    suspend fun requestPrompt(): Response<AiChatResponse>
+    suspend fun requestPrompt(): Response<FinalChatResponse>
 }

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -131,12 +131,8 @@ class HomeChatViewModel @Inject constructor(
                         chatRepository.updateMessageWithReply(
                             id = placeholder.id,
                             replyText = response.textResponse,
-                            detectedMood = response.detectedMood,
                             remoteId = response.replyId
                         )
-                        if (response.action != "balas_teks") {
-                            _pendingAction.value = response.action
-                        }
                     }
                     is Result.Error, null -> {
                         chatRepository.replaceMessage(

--- a/app/src/test/java/com/psy/deardiary/data/repository/ChatRepositoryTest.kt
+++ b/app/src/test/java/com/psy/deardiary/data/repository/ChatRepositoryTest.kt
@@ -5,7 +5,7 @@ import com.psy.deardiary.data.local.ChatMessageDao
 import com.psy.deardiary.data.dto.ChatMessageResponse
 import com.psy.deardiary.data.model.ChatMessage
 import com.psy.deardiary.data.network.ChatApiService
-import com.psy.deardiary.data.dto.AiChatResponse
+import com.psy.deardiary.data.dto.FinalChatResponse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -50,7 +50,7 @@ class ChatRepositoryTest {
     @Test
     fun fetchReplySuccess_returnsSuccess() = runTest {
         whenever(api.sendMessage(any())).thenReturn(
-            Response.success(AiChatResponse("balas_teks", "hi", replyId = 1))
+            Response.success(FinalChatResponse(messageId = 1, replyId = 1, textResponse = "hi"))
         )
 
         val result = repository.fetchReply("hello")

--- a/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/deardiary/features/home/HomeChatViewModelTest.kt
@@ -1,7 +1,7 @@
 import com.psy.deardiary.data.model.ChatMessage
 import com.psy.deardiary.data.repository.ChatRepository
 import com.psy.deardiary.data.repository.Result
-import com.psy.deardiary.data.dto.AiChatResponse
+import com.psy.deardiary.data.dto.FinalChatResponse
 import com.psy.deardiary.features.home.HomeChatViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -47,7 +47,7 @@ class HomeChatViewModelTest {
         whenever(repository.messages).thenReturn(messagesFlow)
         whenever(prefRepo.lastAiPrompt).thenReturn(lastPromptFlow)
         whenever(repository.userPreferencesRepository).thenReturn(prefRepo)
-        whenever(repository.promptChat()).thenReturn(Result.Success(AiChatResponse("balas_teks", "p", null)))
+        whenever(repository.promptChat()).thenReturn(Result.Success(FinalChatResponse(messageId = 1, replyId = 1, textResponse = "p")))
         whenever(repository.refreshMessages()).thenReturn(Result.Success(Unit))
         viewModel = HomeChatViewModel(repository)
     }
@@ -63,14 +63,14 @@ class HomeChatViewModelTest {
         whenever(repository.addMessage(any(), eq(true), eq(false))).thenReturn(userMsg)
         whenever(repository.addMessage(any(), eq(false), eq(true))).thenReturn(ChatMessage(id=2, text="placeholder", isUser=false, isPlaceholder=true, userId = 1))
         whenever(repository.sendMessage("hi", userMsg.id)).thenReturn(
-            Result.Success(AiChatResponse("balas_teks", "hello", "happy", replyId = 3))
+            Result.Success(FinalChatResponse(messageId = 3, replyId = 3, textResponse = "hello"))
         )
         viewModel.sendMessage("hi")
         advanceUntilIdle()
         verify(repository).addMessage("hi", true, false)
         verify(repository).addMessage("Sedang mengetik jawaban...", false, true)
         verify(repository).sendMessage("hi", userMsg.id)
-        verify(repository).updateMessageWithReply(2, "hello", "happy", 3)
+        verify(repository).updateMessageWithReply(2, "hello", null, 3)
     }
 
     @Test
@@ -95,7 +95,7 @@ class HomeChatViewModelTest {
             ChatMessage(id = 2, text = "placeholder", isUser = false, isPlaceholder = true, userId = 1)
         )
         whenever(repository.sendMessage("hi", userMsg.id)).thenReturn(
-            Result.Success(AiChatResponse("balas_teks", "hello", "happy", replyId = 3))
+            Result.Success(FinalChatResponse(messageId = 3, replyId = 3, textResponse = "hello"))
         )
         whenever(repository.syncPendingMessages()).thenReturn(Result.Success(Unit))
 

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -21,7 +21,7 @@ router = APIRouter()
 
 @router.post(
     "/",
-    response_model=schemas.ChatResponse,
+    response_model=schemas.FinalChatResponse,
     summary="Chat with AI",
     description="Send a message and get a short AI-generated reply with sentiment analysis.",
 )
@@ -88,24 +88,16 @@ async def chat_with_ai(
     )
 
     # Removed artificial delay to improve responsiveness.
-    return schemas.ChatResponse(
+    return schemas.FinalChatResponse(
         message_id=created_user_msg.id,
         ai_message_id=created_ai_msg.id,
-        action=action,
         text_response=reply_text,
-        sentiment_score=None,
-        key_emotions=None,
-        detected_mood=detected_mood,
-        issue_type=analysis.get("issue_type") if analysis else None,
-        recommended_technique=analysis.get("technique") if analysis else None,
-        tone=analysis.get("tone") if analysis else None,
-        journal_template=journal_template,
     )
 
 
 @router.post(
     "/messages",
-    response_model=schemas.ChatResponse,
+    response_model=schemas.FinalChatResponse,
     summary="Create message",
     description="Store a chat message and receive an AI response plus sentiment data.",
 )
@@ -159,24 +151,16 @@ async def create_message(
 
     # The simple message endpoint does not store AI responses
 
-    return schemas.ChatResponse(
+    return schemas.FinalChatResponse(
         message_id=created_msg.id,
         ai_message_id=None,
-        action=action,
         text_response=reply_text,
-        sentiment_score=analysis_result.get("sentiment_score") if analysis_result else None,
-        key_emotions=analysis_result.get("key_emotions") if analysis_result else None,
-        detected_mood=detected_mood,
-        issue_type=None,
-        recommended_technique=None,
-        tone=None,
-        journal_template=journal_template,
     )
 
 
 @router.post(
     "/prompt",
-    response_model=schemas.ChatResponse,
+    response_model=schemas.FinalChatResponse,
     summary="Generate prompt",
     description="Let the AI start the conversation when you're inactive.",
 )
@@ -221,12 +205,10 @@ async def prompt_chat(
         db, obj_in=ai_msg, owner_id=current_user.id
     )
 
-    return schemas.ChatResponse(
+    return schemas.FinalChatResponse(
         message_id=created_ai_msg.id,
         ai_message_id=created_ai_msg.id,
-        action=action,
         text_response=reply_text,
-        journal_template=journal_template,
     )
 
 
@@ -340,18 +322,10 @@ async def websocket_chat(websocket: WebSocket, token: str):
                 owner_id=user.id,
             )
 
-            resp = schemas.ChatResponse(
+            resp = schemas.FinalChatResponse(
                 message_id=created_user_msg.id,
                 ai_message_id=created_ai_msg.id,
-                action=action,
                 text_response=reply_text,
-                sentiment_score=None,
-                key_emotions=None,
-                detected_mood=detected_mood,
-                issue_type=analysis.get("issue_type") if analysis else None,
-                recommended_technique=analysis.get("technique") if analysis else None,
-                tone=analysis.get("tone") if analysis else None,
-                journal_template=journal_template,
             )
             await websocket.send_text(resp.model_dump_json())
     finally:

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -3,7 +3,7 @@
 
 from .user import User, UserCreate, UserUpdate, LoginRequest, UserMBTIUpdate
 from .journal import Journal, JournalCreate, JournalUpdate
-from .chat import ChatRequest, ChatResponse
+from .chat import ChatRequest, FinalChatResponse
 from .action import Action, ActionResponse
 from .chat_message import (
     ChatMessage,

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -1,34 +1,11 @@
 from pydantic import BaseModel, Field
-from .action import Action
 
 class ChatRequest(BaseModel):
     message: str = Field(..., description="Message from the user")
 
-class ChatResponse(BaseModel):
+class FinalChatResponse(BaseModel):
     message_id: int = Field(..., description="ID of the created message")
     ai_message_id: int | None = Field(
         None, description="ID of the AI-generated reply message"
     )
-    action: Action = Field(..., description="Action requested by the assistant")
     text_response: str = Field(..., description="Assistant reply text")
-    sentiment_score: float | None = Field(
-        None, description="Sentiment score for the reply"
-    )
-    key_emotions: str | None = Field(
-        None, description="Key emotions detected in the conversation"
-    )
-    detected_mood: str | None = Field(
-        None, description="Overall mood detected from the conversation"
-    )
-    issue_type: str | None = Field(
-        None, description="Detected issue type from the message"
-    )
-    recommended_technique: str | None = Field(
-        None, description="Suggested coping technique"
-    )
-    tone: str | None = Field(
-        None, description="Estimated user tone"
-    )
-    journal_template: str | None = Field(
-        None, description="Suggested journal template when opening the editor"
-    )

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -152,15 +152,7 @@ def test_chat_sentiment_response(client, monkeypatch):
     data = resp.json()
     assert data["message_id"] > 0
     assert data["ai_message_id"] > 0
-    assert data["action"] == "balas_teks"
     assert data["text_response"] == "hi"
-    # Sentiment analysis now runs asynchronously so values are not returned immediately
-    assert data["sentiment_score"] is None
-    assert data["key_emotions"] is None
-    assert data["detected_mood"] == "\U0001F610"
-    assert data["issue_type"] == "stress"
-    assert data["recommended_technique"] == "breathing"
-    assert data["tone"] == "tense"
     assert captured["analysis"] == {
         "issue_type": "stress",
         "technique": "breathing",
@@ -200,9 +192,9 @@ def test_chat_analysis_failure(client, monkeypatch):
     resp = client.post("/api/v1/chat/", json={"message": "hi"}, headers=headers)
     assert resp.status_code == 200
     data = resp.json()
-    assert data["issue_type"] is None
-    assert data["recommended_technique"] is None
-    assert data["tone"] is None
+    assert "issue_type" not in data
+    assert "recommended_technique" not in data
+    assert "tone" not in data
 
 
 def test_message_post_handler(client, monkeypatch):
@@ -232,14 +224,7 @@ def test_message_post_handler(client, monkeypatch):
     data = resp.json()
     assert data["message_id"] > 0
     assert data["ai_message_id"] is None
-    assert data["action"] == "balas_teks"
     assert data["text_response"] == "reply"
-    assert data["sentiment_score"] == 0.2
-    assert data["key_emotions"] == "calm"
-    assert data["detected_mood"] == "\U0001F610"
-    assert data["issue_type"] is None
-    assert data["recommended_technique"] is None
-    assert data["tone"] is None
 
     logs_resp = client.get("/api/v1/emotion/", headers=headers)
     assert logs_resp.status_code == 200
@@ -298,13 +283,9 @@ def test_prompt_endpoint_rate_limit(client, monkeypatch):
     resp = client.post("/api/v1/chat/prompt", headers=headers)
     assert resp.status_code == 200
     data = resp.json()
-    assert data["action"] == "balas_teks"
     assert data["text_response"] == "hey?"
     assert data["message_id"] > 0
     assert data["ai_message_id"] == data["message_id"]
-    assert data["issue_type"] is None
-    assert data["recommended_technique"] is None
-    assert data["tone"] is None
 
     second = client.post("/api/v1/chat/prompt", headers=headers)
     assert second.status_code == 429

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -80,6 +80,3 @@ def test_websocket_chat(client, monkeypatch):
         ws.send_text("hello")
         data = ws.receive_json()
         assert data["text_response"] == "pong"
-        assert data["issue_type"] == "stress"
-        assert data["recommended_technique"] == "breathing"
-        assert data["tone"] == "tense"


### PR DESCRIPTION
## Summary
- rename `ChatResponse` to `FinalChatResponse`
- trim response fields and update API usage
- update tests for new schema
- update Android DTOs and repository

## Testing
- `pytest -q`
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685574ede69483248cc4ef1621f703c2