### PR TITLE
Clean up obsolete chat actions

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
+++ b/app/src/main/java/com/psy/deardiary/data/dto/ChatDtos.kt
@@ -4,11 +4,6 @@ import com.google.gson.annotations.SerializedName
 
 data class ChatRequest(val message: String)
 
-data class ChatResponse(
-    val reply: String,
-    @SerializedName("sentiment_score") val sentimentScore: Float? = null,
-    @SerializedName("key_emotions") val keyEmotions: String? = null
-)
 
 data class ChatMessageResponse(
     val id: Int,
@@ -35,6 +30,8 @@ data class FinalChatResponse(
     @SerializedName("ai_message_id") val replyId: Int?,
     @SerializedName("text_response") val textResponse: String
 )
+
+typealias AiChatResponse = FinalChatResponse
 
 data class DeleteMessagesRequest(
     val ids: List<Int>

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -13,8 +13,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import com.psy.deardiary.data.network.ChatApiService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -47,8 +45,6 @@ class ChatRepository @Inject constructor(
         }
 
     val lastPromptTime: Flow<Long?> = userPreferencesRepository.lastAiPrompt
-    private val _journalTemplate = MutableStateFlow<String?>(null)
-    val journalTemplate = _journalTemplate.asStateFlow()
 
     fun getConversation(): Flow<List<ChatMessage>> =
         messages.onEach { history ->
@@ -264,10 +260,6 @@ class ChatRepository @Inject constructor(
                 Result.Error("Terjadi kesalahan: ${e.message}")
             }
         }
-    }
-
-    fun clearJournalTemplate() {
-        _journalTemplate.value = null
     }
 
     suspend fun getAllMessagesOnce(): List<ChatMessage> {

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -36,10 +36,6 @@ class HomeChatViewModel @Inject constructor(
     private val _messages = MutableStateFlow<List<ChatMessage>>(emptyList())
     val messages = _messages.asStateFlow()
 
-    private val _pendingAction = MutableStateFlow<String?>(null)
-    val pendingAction = _pendingAction.asStateFlow()
-    val journalTemplate = chatRepository.journalTemplate
-
     private val sendMutex = Mutex()
 
     private val _selectedIds = MutableStateFlow<Set<Int>>(emptySet())
@@ -157,8 +153,4 @@ class HomeChatViewModel @Inject constructor(
         _uiState.update { it.copy(errorMessage = null) }
     }
 
-    fun consumeAction() {
-        _pendingAction.value = null
-        chatRepository.clearJournalTemplate()
-    }
 }

--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -36,7 +36,6 @@ import com.psy.deardiary.features.home.components.ArticleSuggestionCard
 import com.psy.deardiary.features.home.components.ChatPromptCard
 import com.psy.deardiary.features.home.FeedItem
 import com.psy.deardiary.ui.components.ConfirmationDialog
-import com.psy.deardiary.ui.components.BreathingDialog
 import com.psy.deardiary.utils.playNotificationFeedback
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalFoundationApi::class) // ANOTASI BARU
@@ -60,22 +59,6 @@ fun HomeScreen(
     val context = LocalContext.current
     var previousAiCount by remember { mutableStateOf<Int?>(null) }
     var showDeleteDialog by remember { mutableStateOf(false) }
-    var showBreathing by remember { mutableStateOf(false) }
-
-    val pendingAction by chatViewModel.pendingAction.collectAsState()
-    val journalTemplate by chatViewModel.journalTemplate.collectAsState()
-
-    LaunchedEffect(pendingAction) {
-        when (pendingAction) {
-            "suggest_breathing_exercise" -> showBreathing = true
-            "open_journal_editor" -> {
-                journalTemplate?.let { onNavigateToEditorWithPrompt(it) }
-                    ?: onNavigateToEditor()
-            }
-            "show_crisis_contact" -> onNavigateToCrisisSupport()
-        }
-        if (pendingAction != null) chatViewModel.consumeAction()
-    }
 
     LaunchedEffect(chatUiState.errorMessage) {
         chatUiState.errorMessage?.let {
@@ -184,9 +167,6 @@ fun HomeScreen(
                     title = "Hapus Pesan",
                     text = "Hapus pesan yang dipilih?"
                 )
-            }
-            if (showBreathing) {
-                BreathingDialog { showBreathing = false }
             }
         }
     }


### PR DESCRIPTION
## Summary
- drop unused ChatResponse data class and map old `AiChatResponse` to `FinalChatResponse`
- remove journal template and pending action handling from repository and view model
- simplify HomeScreen by deleting old action logic and breathing dialog

## Testing
- `gradle test --no-daemon -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855792ef4e48324bc68b896641be259