### PR TITLE
Fix settings extra env variables

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -32,7 +32,8 @@ class Settings(BaseSettings):
     # saat aplikasi dijalankan (yaitu dari dalam folder 'backend')
     model_config = SettingsConfigDict(
         env_file=".env",
-        env_file_encoding="utf-8"
+        env_file_encoding="utf-8",
+        extra="ignore",
     )
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- allow extra environment variables so Celery config doesn't break

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685598e0dda88324b025afd092b00c95