### PR TITLE
Fix AI service headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ AI_API_URL=https://openrouter.ai/api/v1/chat/completions
 AI_MODEL=google/gemini-2.0-flash-001
 AI_PLANNER_MODEL=google/gemini-2.0-flash-001
 AI_GENERATOR_MODEL=google/gemini-2.0-pro-001
+AI_HTTP_REFERER=https://github.com/tanerizawa/diary
+AI_TITLE=Dear Diary App
 
 # Konfigurasi Celery
 CELERY_BROKER_URL=redis://localhost:6379/0

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,3 +23,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES=11520
 AI_API_KEY=isi_dengan_kunci_api_anda
 AI_API_URL=https://openrouter.ai/api/v1/chat/completions
 AI_MODEL=google/gemini-2.0-flash-001
+AI_PLANNER_MODEL=google/gemini-2.0-flash-001
+AI_GENERATOR_MODEL=google/gemini-2.0-pro-001
+AI_HTTP_REFERER=https://github.com/tanerizawa/diary
+AI_TITLE=Dear Diary App

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,6 +20,8 @@ class Settings(BaseSettings):
     # Model khusus untuk perencana percakapan dan generator respons
     AI_PLANNER_MODEL: str
     AI_GENERATOR_MODEL: str
+    AI_HTTP_REFERER: str = "https://github.com/tanerizawa/diary"
+    AI_TITLE: str = "Dear Diary App"
 
     @field_validator("AI_API_KEY")
     @classmethod

--- a/backend/app/services/chat_responder.py
+++ b/backend/app/services/chat_responder.py
@@ -43,9 +43,9 @@ async def get_ai_reply(
     try:
         headers = {
             "Authorization": f"Bearer {settings.AI_API_KEY}",
-            "HTTP-Referer": "https://github.com/tanerizawa/diary",  # Ganti jika perlu
-            "X-Title": "Dear Diary App",
-            "Content-Type": "application/json"
+            "HTTP-Referer": settings.AI_HTTP_REFERER,
+            "X-Title": settings.AI_TITLE,
+            "Content-Type": "application/json",
         }
         # Model diganti sesuai dengan yang ada di .env Anda
         body = {

--- a/backend/app/services/conversation_planner.py
+++ b/backend/app/services/conversation_planner.py
@@ -19,6 +19,8 @@ User message:\n{user_message}
 
     headers = {
         "Authorization": f"Bearer {settings.AI_API_KEY}",
+        "HTTP-Referer": settings.AI_HTTP_REFERER,
+        "X-Title": settings.AI_TITLE,
         "Content-Type": "application/json",
     }
     body = {

--- a/backend/app/services/message_analyzer.py
+++ b/backend/app/services/message_analyzer.py
@@ -14,6 +14,8 @@ async def analyze_message(text: str) -> dict | None:
     """
     headers = {
         "Authorization": f"Bearer {settings.AI_API_KEY}",
+        "HTTP-Referer": settings.AI_HTTP_REFERER,
+        "X-Title": settings.AI_TITLE,
         "Content-Type": "application/json",
     }
     body = {

--- a/backend/app/services/response_generator.py
+++ b/backend/app/services/response_generator.py
@@ -19,6 +19,8 @@ User message:\n{user_message}
 
     headers = {
         "Authorization": f"Bearer {settings.AI_API_KEY}",
+        "HTTP-Referer": settings.AI_HTTP_REFERER,
+        "X-Title": settings.AI_TITLE,
         "Content-Type": "application/json",
     }
     body = {

--- a/backend/app/services/sentiment_analyzer.py
+++ b/backend/app/services/sentiment_analyzer.py
@@ -23,7 +23,9 @@ async def analyze_sentiment_with_ai(text: str) -> dict | None:
 
     headers = {
         "Authorization": f"Bearer {settings.AI_API_KEY}",
-        "Content-Type": "application/json"
+        "HTTP-Referer": settings.AI_HTTP_REFERER,
+        "X-Title": settings.AI_TITLE,
+        "Content-Type": "application/json",
     }
 
     # Model yang akan digunakan (contoh: Google Gemini Flash)


### PR DESCRIPTION
## Summary
- add `AI_HTTP_REFERER` and `AI_TITLE` defaults in config
- send those headers with all OpenRouter requests
- document new env variables in `.env.example` files

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a3aaad908324980d934a360861ca