### PR TITLE
Fix chat delay and planner errors

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeChatViewModel.kt
@@ -109,13 +109,9 @@ class HomeChatViewModel @Inject constructor(
                     isPlaceholder = true
                 )
 
-                // 3. Tunda pengiriman pesan sekitar 5 detik untuk meniru jeda ketik
-                //    manusia mengetik. Setelah itu baru teruskan ke server.
-                delay(5_000)
-
-                // 4. Panggil API dengan batas waktu lebih lama agar server punya waktu
-                //    yang cukup untuk merespons. Batas lama sebelumnya kadang terlalu
-                //    singkat sehingga balasan AI tidak sempat diterima sepenuhnya.
+                // 3. Panggil API dengan batas waktu yang cukup agar server dapat
+                //    merespons sambil placeholder tetap ditampilkan sebagai efek
+                //    "sedang mengetik".
                 val result = withTimeoutOrNull(30_000) {
                     chatRepository.sendMessage(text, userMsg.id)
                 }

--- a/backend/app/services/conversation_planner.py
+++ b/backend/app/services/conversation_planner.py
@@ -41,10 +41,12 @@ User message:\n{user_message}
             data = resp.json()
             content = data["choices"][0]["message"]["content"]
             parsed = json.loads(content)
+            if not isinstance(parsed, dict):
+                raise ValueError("Invalid JSON structure")
             technique = parsed.get("technique")
             if not isinstance(technique, str):
                 raise ValueError("Invalid technique")
             return ConversationPlan(technique=technique)
-    except (httpx.RequestError, httpx.HTTPStatusError, json.JSONDecodeError, KeyError, ValueError) as e:
+    except (httpx.RequestError, httpx.HTTPStatusError, json.JSONDecodeError, KeyError, ValueError, AttributeError) as e:
         print(f"Error calling conversation planner: {e}")
         return None


### PR DESCRIPTION
## Summary
- handle conversation planner failures when JSON structure is unexpected
- remove artificial delay before sending messages while keeping typing indicator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a78105b08324acf1c5562350df1d