### PR TITLE
Add communication technique enum and toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,11 @@ celery -A backend.app.celery_app.celery_app worker --loglevel=info
 ## Contributing
 
 Pull requests are welcome. Please open an issue first to discuss major changes. Make sure all tests pass before submitting.
+
+## Conversation toolbox
+
+The backend includes a small "toolbox" of communication techniques used by the
+AI assistant. Each technique is defined in `CommunicationTechnique` and mapped
+to a short instruction in `conversation_planner.TOOLBOX`. The planner chooses
+one technique for each reply (for example *Reflecting* or *Summarizing*). To add
+new techniques, extend this enum and dictionary.

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -17,4 +17,4 @@ from .emotion_log import (
     EmotionLogCreate,
     EmotionLogUpdate,
 )
-from .conversation import ConversationPlan
+from .conversation import ConversationPlan, CommunicationTechnique

--- a/backend/app/schemas/conversation.py
+++ b/backend/app/schemas/conversation.py
@@ -1,10 +1,29 @@
+from enum import Enum
 from pydantic import BaseModel, Field
+
+
+class CommunicationTechnique(str, Enum):
+    """Enumeration of counselling techniques used by the assistant."""
+
+    PROBING = "Probing"
+    CLARIFYING = "Clarifying"
+    PARAPHRASING = "Paraphrasing"
+    REFLECTING = "Reflecting"
+    OPEN_ENDED_QUESTIONS = "Open-ended questions"
+    CLOSED_ENDED_QUESTIONS = "Closed-ended questions"
+    SUMMARIZING = "Summarizing"
+    CONFRONTATION = "Confrontation"
+    REASSURANCE_ENCOURAGEMENT = "Reassurance and encouragement"
+
 
 class ConversationPlan(BaseModel):
     """Technique chosen for guiding the next assistant reply."""
-    technique: str = Field(..., description="Conversation technique to apply")
+
+    technique: CommunicationTechnique = Field(
+        ..., description="Conversation technique to apply"
+    )
 
     @property
     def technique_to_use(self) -> str:
-        """Alias property for the technique string."""
-        return self.technique
+        """Return the human readable technique name."""
+        return self.technique.value

--- a/backend/app/services/response_generator.py
+++ b/backend/app/services/response_generator.py
@@ -4,14 +4,17 @@ import httpx
 
 from app.core.config import settings
 from app.schemas.conversation import ConversationPlan
+from app.services.conversation_planner import TOOLBOX
 
 
 async def generate_pure_response(plan: ConversationPlan, user_message: str) -> str:
     """Generate a plain text reply applying the given conversation technique."""
     technique = plan.technique_to_use
+    instruction = TOOLBOX.get(plan.technique, "")
     prompt = f"""
 You are the 'actor' persona executing the assistant's reply.
 Follow the director's instructions exactly and use this technique: {technique}.
+To apply it, {instruction}.
 Respond directly to the user in Bahasa Indonesia without any JSON or formatting.
 
 User message:\n{user_message}

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -19,7 +19,7 @@ from app.db import Base
 from app.api import deps
 from app import crud
 from backend.main import app
-from app.schemas.conversation import ConversationPlan
+from app.schemas.conversation import ConversationPlan, CommunicationTechnique
 
 
 @pytest.fixture
@@ -122,7 +122,7 @@ def test_chat_sentiment_response(client, monkeypatch):
     captured = {}
     async def fake_plan(context: str, user_message: str):
         captured["ctx"] = context
-        return ConversationPlan(technique="mirror")
+        return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
     async def fake_generate(plan: ConversationPlan, user_message: str):
         return "hi"
@@ -174,7 +174,7 @@ def test_chat_analysis_failure(client, monkeypatch):
     headers = register_and_login(client, email="fail@example.com")
 
     async def fake_plan(context: str, user_message: str):
-        return ConversationPlan(technique="mirror")
+        return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
     async def fake_generate(plan: ConversationPlan, user_message: str):
         return "ok"
@@ -203,7 +203,7 @@ def test_message_post_handler(client, monkeypatch):
     headers = register_and_login(client, email="msg@example.com")
 
     async def fake_plan(context: str, user_message: str):
-        return ConversationPlan(technique="mirror")
+        return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
     async def fake_generate(plan: ConversationPlan, user_message: str):
         return "reply"
@@ -240,7 +240,7 @@ def test_delete_messages_endpoint(client, monkeypatch):
     headers = register_and_login(client, email="delmsg@example.com")
 
     async def fake_plan(context: str, user_message: str):
-        return ConversationPlan(technique="mirror")
+        return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
     async def fake_generate(plan: ConversationPlan, user_message: str):
         return "ok"
@@ -274,7 +274,7 @@ def test_prompt_endpoint_rate_limit(client, monkeypatch):
     headers = register_and_login(client, email="prompt@example.com")
 
     async def fake_plan(context: str, user_message: str):
-        return ConversationPlan(technique="mirror")
+        return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
     async def fake_generate(plan: ConversationPlan, user_message: str):
         return "hey?"
@@ -299,7 +299,7 @@ def test_relationship_level_prompt_variation(client, monkeypatch):
 
     async def fake_plan(context: str, user_message: str):
         prompts.append(context)
-        return ConversationPlan(technique="mirror")
+        return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
     async def fake_generate(plan: ConversationPlan, user_message: str):
         return "ok"

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -59,7 +59,7 @@ def register_and_login(client, email="user@example.com", password="pass"):
     return {"Authorization": f"Bearer {token}"}
 
 
-from app.schemas.conversation import ConversationPlan
+from app.schemas.conversation import ConversationPlan, CommunicationTechnique
 
 
 def test_chat_context_assembly(client, monkeypatch):
@@ -67,7 +67,7 @@ def test_chat_context_assembly(client, monkeypatch):
 
     async def fake_plan(context: str, user_message: str):
         captured["context"] = context
-        return ConversationPlan(technique="mirror")
+        return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
     async def fake_generate(plan: ConversationPlan, user_message: str):
         return "ok"
@@ -125,7 +125,7 @@ def test_prompt_context_assembly(client, monkeypatch):
 
     async def fake_plan(context: str, user_message: str):
         captured["context"] = context
-        return ConversationPlan(technique="mirror")
+        return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
     async def fake_generate(plan: ConversationPlan, user_message: str):
         return "ok"

--- a/backend/tests/test_response_generator.py
+++ b/backend/tests/test_response_generator.py
@@ -12,7 +12,7 @@ import httpx
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from app.schemas.conversation import ConversationPlan
+from app.schemas.conversation import ConversationPlan, CommunicationTechnique
 from app.services.response_generator import generate_pure_response
 
 
@@ -39,8 +39,8 @@ def test_generate_pure_response_prompt(monkeypatch):
             return Resp()
 
     monkeypatch.setattr("app.services.response_generator.httpx.AsyncClient", DummyClient)
-    plan = ConversationPlan(technique="mirroring")
+    plan = ConversationPlan(technique=CommunicationTechnique.REFLECTING)
     result = asyncio.run(generate_pure_response(plan, "hi"))
     assert result == "reply"
-    assert "mirroring" in captured['json']['messages'][0]['content']
+    assert "Reflecting" in captured['json']['messages'][0]['content']
     assert 'response_format' not in captured['json']

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from app.db import Base
 from app.api import deps
 from backend.main import app
-from app.schemas.conversation import ConversationPlan
+from app.schemas.conversation import ConversationPlan, CommunicationTechnique
 
 
 @pytest.fixture
@@ -65,7 +65,7 @@ def test_websocket_chat(client, monkeypatch):
     token = register_and_login(client)
 
     async def fake_plan(context: str, user_message: str):
-        return ConversationPlan(technique="mirror")
+        return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
     async def fake_generate(plan: ConversationPlan, user_message: str):
         return "pong"


### PR DESCRIPTION
## Summary
- define `CommunicationTechnique` enum and update `ConversationPlan`
- implement a toolbox dictionary and add planner fallback logic
- update `generate_pure_response` to include toolbox instructions
- adjust planner prompt and parse technique names case-insensitively
- update tests and documentation for new enum

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b1c569b48324ae493142c705b6dd