### PR TITLE
Remove mood-based greeting

### DIFF
--- a/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/deardiary/features/home/HomeScreen.kt
@@ -334,11 +334,8 @@ private fun composeGreeting(
     timeOfDay: String,
     name: String,
     lastMood: String?,
-    sentiment: Float?
+    sentiment: Float?,
 ): String {
-    return when {
-        sentiment != null && sentiment < 0 -> "Aku di sini untukmu, $name. Ceritakan apa yang kamu rasakan."
-        lastMood == "\uD83D\uDE22" -> "Aku di sini untukmu, $name. Ceritakan apa yang kamu rasakan."
-        else -> "$timeOfDay, $name."
-    }
+    return "$timeOfDay, $name."
+}
 }


### PR DESCRIPTION
## Summary
- drop mood-specific greeting from `composeGreeting`

## Testing
- `pytest -q`
- `./gradlew test --quiet` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6855bb0a082c83248ddd14a410e9f21d