### PR TITLE
Remove chat onboarding logic

### DIFF
--- a/app/src/main/java/com/psy/deardiary/data/datastore/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/datastore/UserPreferencesRepository.kt
@@ -7,7 +7,6 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -29,7 +28,6 @@ class UserPreferencesRepository @Inject constructor(@ApplicationContext context:
         // PENAMBAHAN BARU: Key untuk menyimpan nomor kontak darurat
         val EMERGENCY_CONTACT = stringPreferencesKey("emergency_contact_number")
         val USER_ID = intPreferencesKey("user_id")
-        val CHAT_ONBOARD_SHOWN = booleanPreferencesKey("chat_onboard_shown")
         val LAST_AI_PROMPT = longPreferencesKey("last_ai_prompt")
     }
 
@@ -50,9 +48,6 @@ class UserPreferencesRepository @Inject constructor(@ApplicationContext context:
         prefs[PreferencesKeys.LAST_AI_PROMPT]
     }
 
-    val chatOnboardShown: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[PreferencesKeys.CHAT_ONBOARD_SHOWN] ?: false
-    }
 
     suspend fun saveAuthToken(token: String) {
         dataStore.edit { preferences ->
@@ -66,11 +61,6 @@ class UserPreferencesRepository @Inject constructor(@ApplicationContext context:
         }
     }
 
-    suspend fun setChatOnboardShown(shown: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.CHAT_ONBOARD_SHOWN] = shown
-        }
-    }
 
     suspend fun setLastAiPrompt(timestamp: Long) {
         dataStore.edit { prefs ->

--- a/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/psy/deardiary/data/repository/ChatRepository.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.map
 import com.psy.deardiary.data.network.ChatApiService
 import kotlinx.coroutines.Dispatchers
@@ -46,19 +45,7 @@ class ChatRepository @Inject constructor(
 
     val lastPromptTime: Flow<Long?> = userPreferencesRepository.lastAiPrompt
 
-    fun getConversation(): Flow<List<ChatMessage>> =
-        messages.onEach { history ->
-            if (history.isEmpty()) {
-                val shown = userPreferencesRepository.chatOnboardShown.first()
-                if (!shown) {
-                    addMessage(
-                        "Hai! Aku teman bicaramu di sini. Ceritakan apa yang kamu rasakan.",
-                        isUser = false
-                    )
-                    userPreferencesRepository.setChatOnboardShown(true)
-                }
-            }
-        }
+    fun getConversation(): Flow<List<ChatMessage>> = messages
 
     suspend fun refreshMessages(): Result<Unit> {
         return withContext(Dispatchers.IO) {


### PR DESCRIPTION
## Summary
- simplify ChatRepository#getConversation
- drop CHAT_ONBOARD_SHOWN preferences

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c45669348324baa20a72e67f6529