### PR TITLE
Add reasoning field to conversation planner

### DIFF
--- a/backend/tests/test_conversation_planner.py
+++ b/backend/tests/test_conversation_planner.py
@@ -27,7 +27,7 @@ def test_plan_conversation_strategy_parses_json(monkeypatch):
                 def raise_for_status(self):
                     pass
                 def json(self):
-                    return {"choices": [{"message": {"content": '{"technique":"reflection"}'}}]}
+                    return {"choices": [{"message": {"content": '{"reasoning":"ok","technique":"reflection"}'}}]}
             return Resp()
 
     monkeypatch.setattr("app.services.conversation_planner.httpx.AsyncClient", DummyClient)
@@ -67,7 +67,7 @@ def test_plan_conversation_strategy_unknown(monkeypatch):
                     pass
 
                 def json(self):
-                    return {"choices": [{"message": {"content": '{"technique":"nonsense"}'}}]}
+                    return {"choices": [{"message": {"content": '{"reasoning":"?","technique":"nonsense"}'}}]}
 
             return Resp()
 


### PR DESCRIPTION
## Summary
- extend conversation planner prompt with chain-of-thought steps and negative instructions
- log optional reasoning returned by AI service
- adjust tests for new JSON structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685635a127e08324910cb2aaac205976