### PR TITLE
Improve AI planner technique parsing

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ python-multipart
 httpx # PENAMBAHAN BARU
 structlog
 transformers
+thefuzz[speedup]
 
 # Task queue
 celery


### PR DESCRIPTION
## Summary
- parse returned technique names more flexibly with `thefuzz`
- log unknown techniques as suggestions
- depend on `thefuzz[speedup]`
- test fuzzy match behaviour

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest backend/tests/test_conversation_planner.py::test_plan_conversation_strategy_fuzzy_match -q`
- `pytest -q backend/tests/test_conversation_planner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685638b56d208324a4d9a43f7811476b