### PR TITLE
Add neutral acknowledgement strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,6 @@ Pull requests are welcome. Please open an issue first to discuss major changes. 
 The backend includes a small "toolbox" of communication techniques used by the
 AI assistant. Each technique is defined in `CommunicationTechnique` and mapped
 to a short instruction in `conversation_planner.TOOLBOX`. The planner chooses
-one technique for each reply (for example *Reflecting* or *Summarizing*). To add
-new techniques, extend this enum and dictionary.
+one technique for each reply (for example *Reflecting*, *Summarizing* or the
+new *Neutral acknowledgement* technique). To add new techniques, extend this
+enum and dictionary.

--- a/backend/app/schemas/conversation.py
+++ b/backend/app/schemas/conversation.py
@@ -14,6 +14,7 @@ class CommunicationTechnique(str, Enum):
     SUMMARIZING = "Summarizing"
     CONFRONTATION = "Confrontation"
     REASSURANCE_ENCOURAGEMENT = "Reassurance and encouragement"
+    NEUTRAL_ACKNOWLEDGEMENT = "Neutral acknowledgement"
 
 
 class ConversationPlan(BaseModel):

--- a/backend/app/services/conversation_planner.py
+++ b/backend/app/services/conversation_planner.py
@@ -20,6 +20,7 @@ TOOLBOX: dict[CommunicationTechnique, str] = {
     CommunicationTechnique.SUMMARIZING: "briefly recap key points",
     CommunicationTechnique.CONFRONTATION: "gently note inconsistencies",
     CommunicationTechnique.REASSURANCE_ENCOURAGEMENT: "offer reassurance",
+    CommunicationTechnique.NEUTRAL_ACKNOWLEDGEMENT: "give a brief neutral acknowledgement",
 }
 
 SYNONYMS = {
@@ -137,7 +138,7 @@ User message:\n{user_message}
                         "planner_new_technique_suggestion",
                         suggestion=technique_str,
                     )
-                    tech_enum = CommunicationTechnique.PROBING
+                    tech_enum = CommunicationTechnique.NEUTRAL_ACKNOWLEDGEMENT
             log.info(
                 "planner_success", technique=tech_enum.value, reasoning=reasoning
             )

--- a/backend/tests/test_conversation_planner.py
+++ b/backend/tests/test_conversation_planner.py
@@ -73,7 +73,7 @@ def test_plan_conversation_strategy_unknown(monkeypatch):
 
     monkeypatch.setattr("app.services.conversation_planner.httpx.AsyncClient", DummyClient)
     plan = asyncio.run(plan_conversation_strategy("ctx", "hi"))
-    assert plan.technique == CommunicationTechnique.PROBING
+    assert plan.technique == CommunicationTechnique.NEUTRAL_ACKNOWLEDGEMENT
 
 
 def test_plan_conversation_strategy_fuzzy_match(monkeypatch):


### PR DESCRIPTION
## Summary
- support `NEUTRAL_ACKNOWLEDGEMENT` strategy
- describe technique and usage in README
- ensure conversation planner defaults to neutral acknowledgement
- test the new fallback behaviour

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563afc46d88324a3d6243eb1a59b35