### PR TITLE
Add persona traits and context to AI prompts

### DIFF
--- a/backend/app/services/response_generator.py
+++ b/backend/app/services/response_generator.py
@@ -8,16 +8,22 @@ from app.schemas.conversation import ConversationPlan
 from app.services.conversation_planner import TOOLBOX
 
 
-async def generate_pure_response(plan: ConversationPlan, user_message: str) -> str:
+async def generate_pure_response(
+    plan: ConversationPlan,
+    user_message: str,
+    context: str,
+    persona_trait: str,
+) -> str:
     """Generate a plain text reply applying the given conversation technique."""
     log = structlog.get_logger(__name__)
     technique = plan.technique_to_use
     instruction = TOOLBOX.get(plan.technique, "")
     prompt = f"""
-You are the 'actor' persona executing the assistant's reply.
-Follow the director's instructions exactly and use this technique: {technique}.
-To apply it, {instruction}.
+You are Kai, a warm, empathetic, and non-judgmental friend. {persona_trait}
+The conversation director has decided you should use the '{plan.technique.value}' technique when responding. To apply it, {instruction}.
 Respond directly to the user in Bahasa Indonesia without any JSON or formatting.
+
+Context:\n{context}
 
 User message:\n{user_message}
 """
@@ -37,6 +43,7 @@ User message:\n{user_message}
         "generator_request",
         technique=technique,
         user_message=user_message,
+        context_length=len(context),
     )
 
     try:

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -133,7 +133,9 @@ def test_chat_sentiment_response(client, monkeypatch):
         captured["ctx"] = context
         return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
-    async def fake_generate(plan: ConversationPlan, user_message: str):
+    async def fake_generate(
+        plan: ConversationPlan, user_message: str, context: str, persona_trait: str
+    ):
         return "hi"
 
     async def fake_analysis(text: str):
@@ -190,7 +192,9 @@ def test_chat_analysis_failure(client, monkeypatch):
     ):
         return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
-    async def fake_generate(plan: ConversationPlan, user_message: str):
+    async def fake_generate(
+        plan: ConversationPlan, user_message: str, context: str, persona_trait: str
+    ):
         return "ok"
 
     async def fail_analysis(text: str):
@@ -226,7 +230,9 @@ def test_message_post_handler(client, monkeypatch):
     ):
         return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
-    async def fake_generate(plan: ConversationPlan, user_message: str):
+    async def fake_generate(
+        plan: ConversationPlan, user_message: str, context: str, persona_trait: str
+    ):
         return "reply"
 
     async def fake_sentiment(text: str):
@@ -269,7 +275,9 @@ def test_delete_messages_endpoint(client, monkeypatch):
     ):
         return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
-    async def fake_generate(plan: ConversationPlan, user_message: str):
+    async def fake_generate(
+        plan: ConversationPlan, user_message: str, context: str, persona_trait: str
+    ):
         return "ok"
 
     async def fake_sentiment(text: str):
@@ -313,7 +321,9 @@ def test_prompt_endpoint_rate_limit(client, monkeypatch):
     ):
         return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
-    async def fake_generate(plan: ConversationPlan, user_message: str):
+    async def fake_generate(
+        plan: ConversationPlan, user_message: str, context: str, persona_trait: str
+    ):
         return "hey?"
 
     monkeypatch.setattr(
@@ -344,7 +354,9 @@ def test_relationship_level_prompt_variation(client, monkeypatch):
         prompts.append(context)
         return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
-    async def fake_generate(plan: ConversationPlan, user_message: str):
+    async def fake_generate(
+        plan: ConversationPlan, user_message: str, context: str, persona_trait: str
+    ):
         return "ok"
 
     monkeypatch.setattr(

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -77,7 +77,9 @@ def test_chat_context_assembly(client, monkeypatch):
         captured["context"] = context
         return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
-    async def fake_generate(plan: ConversationPlan, user_message: str):
+    async def fake_generate(
+        plan: ConversationPlan, user_message: str, context: str, persona_trait: str
+    ):
         return "ok"
 
     monkeypatch.setattr(
@@ -146,7 +148,9 @@ def test_prompt_context_assembly(client, monkeypatch):
         captured["context"] = context
         return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
-    async def fake_generate(plan: ConversationPlan, user_message: str):
+    async def fake_generate(
+        plan: ConversationPlan, user_message: str, context: str, persona_trait: str
+    ):
         return "ok"
 
     monkeypatch.setattr(

--- a/backend/tests/test_response_generator.py
+++ b/backend/tests/test_response_generator.py
@@ -40,7 +40,11 @@ def test_generate_pure_response_prompt(monkeypatch):
 
     monkeypatch.setattr("app.services.response_generator.httpx.AsyncClient", DummyClient)
     plan = ConversationPlan(technique=CommunicationTechnique.REFLECTING)
-    result = asyncio.run(generate_pure_response(plan, "hi"))
+    result = asyncio.run(
+        generate_pure_response(plan, "hi", "ctx", "persona")
+    )
     assert result == "reply"
-    assert "Reflecting" in captured['json']['messages'][0]['content']
+    msg = captured['json']['messages'][0]['content']
+    assert "Reflecting" in msg
+    assert "Kai" in msg
     assert 'response_format' not in captured['json']

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -75,7 +75,9 @@ def test_websocket_chat(client, monkeypatch):
     ):
         return ConversationPlan(technique=CommunicationTechnique.REFLECTING)
 
-    async def fake_generate(plan: ConversationPlan, user_message: str):
+    async def fake_generate(
+        plan: ConversationPlan, user_message: str, context: str, persona_trait: str
+    ):
         return "pong"
 
     async def fake_analysis(text: str):


### PR DESCRIPTION
## Summary
- extend `generate_pure_response` to include `context` and `persona_trait`
- provide relationship-based persona traits when generating responses
- update chat endpoints and websocket handler to supply context and persona info
- adjust tests for new argument signature and verify persona text in prompts

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685642698a7883249d90d57331904327