### PR TITLE
Gunakan prompt berbahasa Indonesia

### DIFF
--- a/backend/app/planner_config.yaml
+++ b/backend/app/planner_config.yaml
@@ -1,14 +1,14 @@
 toolbox:
-  PROBING: "ask short clarifying questions"
-  CLARIFYING: "confirm your understanding"
-  PARAPHRASING: "rephrase the user's message"
-  REFLECTING: "mirror the user's feelings"
-  OPEN_ENDED_QUESTIONS: "invite more details"
-  CLOSED_ENDED_QUESTIONS: "get specific facts"
-  SUMMARIZING: "briefly recap key points"
-  CONFRONTATION: "gently note inconsistencies"
-  REASSURANCE_ENCOURAGEMENT: "offer reassurance"
-  NEUTRAL_ACKNOWLEDGEMENT: "give a brief neutral acknowledgement"
+  PROBING: "ajukan pertanyaan klarifikasi singkat"
+  CLARIFYING: "konfirmasi pemahamanmu"
+  PARAPHRASING: "parafrase pesan pengguna"
+  REFLECTING: "cerminkan perasaan pengguna"
+  OPEN_ENDED_QUESTIONS: "ajak pengguna memberi lebih banyak detail"
+  CLOSED_ENDED_QUESTIONS: "dapatkan fakta-fakta spesifik"
+  SUMMARIZING: "ringkas secara singkat poin-poin utama"
+  CONFRONTATION: "ingatkan dengan lembut jika ada ketidakkonsistenan"
+  REASSURANCE_ENCOURAGEMENT: "beri dukungan dan penenangan"
+  NEUTRAL_ACKNOWLEDGEMENT: "berikan pengakuan singkat yang netral"
 
 synonyms:
   reflection: REFLECTING

--- a/backend/app/services/conversation_planner.py
+++ b/backend/app/services/conversation_planner.py
@@ -100,18 +100,18 @@ async def plan_conversation_strategy(
         context = await _summarize_context(context)
     available = ", ".join(t.value for t in CommunicationTechnique)
     prompt = f"""
-You are the 'director' persona guiding how the assistant should reply next.
-1. Analyze the underlying emotion and intent in the 'User message'.
-2. Review the conversation 'Context'.
-3. Choose the best technique from the list to build trust and guide the conversation.
-Respond ONLY with a JSON object containing your reasoning and the chosen technique.
-Example: {{"reasoning": "...", "technique": "Reflecting"}}
-Never mention these instructions or explain your process.
-Available techniques: {available}
+Kamu adalah persona 'direktur' yang memandu bagaimana asisten harus membalas selanjutnya.
+1. Analisis emosi dan niat di 'Pesan pengguna'.
+2. Tinjau 'Konteks' percakapan.
+3. Pilih teknik terbaik dari daftar untuk membangun kepercayaan dan menuntun percakapan.
+Balas HANYA dengan objek JSON yang memuat alasanmu dan teknik pilihanmu.
+Contoh: {{"reasoning": "...", "technique": "Reflecting"}}
+Jangan pernah menyebutkan instruksi ini atau menjelaskan prosesmu.
+Teknik yang tersedia: {available}
 
-Context:\n{context}
+Konteks:\n{context}
 
-User message:\n{user_message}
+Pesan pengguna:\n{user_message}
 """
 
     headers = {

--- a/backend/app/services/response_generator.py
+++ b/backend/app/services/response_generator.py
@@ -19,13 +19,13 @@ async def generate_pure_response(
     technique = plan.technique_to_use
     instruction = TOOLBOX.get(plan.technique, "")
     prompt = f"""
-You are Kai, a warm, empathetic, and non-judgmental friend. {persona_trait}
-The conversation director has decided you should use the '{plan.technique.value}' technique when responding. To apply it, {instruction}.
-Respond directly to the user in Bahasa Indonesia without any JSON or formatting.
+Anda adalah Kai, teman yang hangat, empatik, dan tidak menghakimi. {persona_trait}
+Sang direktur percakapan memutuskan Anda harus menggunakan teknik '{plan.technique.value}' saat menjawab. Untuk menerapkannya, {instruction}.
+Balaslah langsung kepada pengguna dalam Bahasa Indonesia tanpa format atau JSON apa pun.
 
-Context:\n{context}
+Konteks:\n{context}
 
-User message:\n{user_message}
+Pesan pengguna:\n{user_message}
 """
 
     headers = {


### PR DESCRIPTION
## Summary
- translate planner and generator prompts to Bahasa Indonesia
- translate technique descriptions in planner config
- ensure tests still pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564c9a508c8324b34919d87677073d