### PR TITLE
Handle invalid planner config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,5 @@ and a `synonyms` section for alternative names. `conversation_planner` loads thi
 at startup (or the path specified via the `PLANNER_CONFIG_FILE` setting) and exposes
 the resulting `TOOLBOX` dictionary for the response generator. To add or modify
 techniques, edit this YAML file and extend the `CommunicationTechnique` enum.
+If `PLANNER_CONFIG_FILE` points to a missing or malformed file, the planner
+logs a warning and falls back to empty dictionaries.


### PR DESCRIPTION
## Summary
- make `_load_config` return empty config on missing or malformed YAML and log warning
- document the fallback behaviour
- test missing/malformed planner config file

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856511c51dc83249e03062a6eea93e4