### PR TITLE
Add sentiment emotion analyzer

### DIFF
--- a/backend/app/db/models/chat.py
+++ b/backend/app/db/models/chat.py
@@ -14,5 +14,6 @@ class ChatMessage(Base):
     sentiment_score = Column(Float, nullable=True)
     key_emotions = Column(Text, nullable=True)
     detected_mood = Column(String, nullable=True)
+    primary_emotion = Column(String, nullable=True)
 
     owner = relationship("User")

--- a/backend/app/db/models/emotion_log.py
+++ b/backend/app/db/models/emotion_log.py
@@ -14,5 +14,6 @@ class EmotionLog(Base):
     source_feature = Column(String)
     sentiment_score = Column(Float, nullable=True)
     key_emotions_detected = Column(JSON, nullable=True)
+    primary_emotion = Column(String, nullable=True)
 
     user = relationship("User")

--- a/backend/app/db/models/journal.py
+++ b/backend/app/db/models/journal.py
@@ -17,6 +17,7 @@ class JournalEntry(Base):
     # Kolom untuk menyimpan hasil analisis AI, bisa null
     sentiment_score = Column(Float, nullable=True)
     key_emotions = Column(String, nullable=True)
+    primary_emotion = Column(String, nullable=True)
     # --- AKHIR PENAMBAHAN ---
 
     owner = relationship("User", back_populates="journals")

--- a/backend/app/schemas/chat_message.py
+++ b/backend/app/schemas/chat_message.py
@@ -10,6 +10,9 @@ class ChatMessageBase(BaseModel):
     key_emotions: str | None = Field(
         None, description="Key emotions extracted from the message"
     )
+    primary_emotion: str | None = Field(
+        None, description="Primary emotion detected from the message"
+    )
     detected_mood: str | None = Field(
         None, description="Detected mood from the message"
     )

--- a/backend/app/schemas/emotion_log.py
+++ b/backend/app/schemas/emotion_log.py
@@ -13,6 +13,9 @@ class EmotionLogBase(BaseModel):
     key_emotions_detected: list[str] | None = Field(
         None, description="List of key emotions extracted"
     )
+    primary_emotion: str | None = Field(
+        None, description="Primary emotion identified"
+    )
 
 class EmotionLogCreate(EmotionLogBase):
     pass

--- a/backend/app/schemas/journal.py
+++ b/backend/app/schemas/journal.py
@@ -26,6 +26,9 @@ class Journal(JournalBase):
     key_emotions: str | None = Field(
         None, description="Key emotions extracted from the entry"
     )
+    primary_emotion: str | None = Field(
+        None, description="Primary emotion detected from the entry"
+    )
     # --- AKHIR PENAMBAHAN ---
 
     # Config untuk kompatibilitas dengan ORM

--- a/backend/app/services/sentiment_emotion_analyzer.py
+++ b/backend/app/services/sentiment_emotion_analyzer.py
@@ -1,0 +1,46 @@
+import httpx
+import json
+from app.core.config import settings
+
+async def analyze_sentiment_and_emotions(text: str) -> dict | None:
+    """Analyze *text* for sentiment and emotions using the AI service."""
+    prompt = f"""
+    Analyze the sentiment and emotions of the following text.
+    Respond only with raw JSON having these keys:
+    sentiment_score - float between -1.0 and 1.0
+    emotions - comma separated list of emotions present
+    primary_emotion - the single emotion that best represents the text
+
+    Text: "{text}"
+    """
+    headers = {
+        "Authorization": f"Bearer {settings.AI_API_KEY}",
+        "HTTP-Referer": settings.AI_HTTP_REFERER,
+        "X-Title": settings.AI_TITLE,
+        "Content-Type": "application/json",
+    }
+    body = {
+        "model": settings.AI_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "response_format": {"type": "json_object"},
+    }
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                url=settings.AI_API_URL,
+                headers=headers,
+                json=body,
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            content = data["choices"][0]["message"]["content"]
+            result = json.loads(content)
+            return {
+                "sentiment_score": result.get("sentiment_score"),
+                "emotions": result.get("emotions"),
+                "primary_emotion": result.get("primary_emotion"),
+            }
+    except (httpx.RequestError, httpx.HTTPStatusError, json.JSONDecodeError, KeyError) as e:
+        print(f"Error calling sentiment/emotion service: {e}")
+        return None

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -2,7 +2,7 @@ import asyncio
 from .celery_app import celery_app
 from app.db.session import SessionLocal
 from app import crud
-from app.services.sentiment_analyzer import analyze_sentiment_with_ai
+from app.services.sentiment_emotion_analyzer import analyze_sentiment_and_emotions
 
 @celery_app.task
 def process_journal_sentiment(journal_id: int):
@@ -10,10 +10,11 @@ def process_journal_sentiment(journal_id: int):
     try:
         journal = crud.journal.get(db=db, id=journal_id)
         if journal:
-            result = asyncio.run(analyze_sentiment_with_ai(journal.content))
+            result = asyncio.run(analyze_sentiment_and_emotions(journal.content))
             if result:
                 journal.sentiment_score = result.get("sentiment_score")
-                journal.key_emotions = result.get("key_emotions")
+                journal.key_emotions = result.get("emotions")
+                journal.primary_emotion = result.get("primary_emotion")
                 db.add(journal)
                 db.commit()
                 db.refresh(journal)
@@ -26,10 +27,11 @@ def process_chat_sentiment(chat_id: int):
     try:
         msg = crud.chat_message.get(db=db, id=chat_id)
         if msg:
-            result = asyncio.run(analyze_sentiment_with_ai(msg.text))
+            result = asyncio.run(analyze_sentiment_and_emotions(msg.text))
             if result:
                 msg.sentiment_score = result.get("sentiment_score")
-                msg.key_emotions = result.get("key_emotions")
+                msg.key_emotions = result.get("emotions")
+                msg.primary_emotion = result.get("primary_emotion")
                 db.add(msg)
                 db.commit()
                 db.refresh(msg)

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -49,9 +49,9 @@ def test_process_journal_sentiment(db, monkeypatch):
     journal = crud.journal.create_with_owner(db, obj_in=schemas.JournalCreate(title="t", content="c", mood="ok", timestamp=1), owner_id=user.id)
 
     async def fake_analyze(text: str):
-        return {"sentiment_score": 1.0, "key_emotions": "happy"}
+        return {"sentiment_score": 1.0, "emotions": "happy", "primary_emotion": "happy"}
 
-    monkeypatch.setattr("app.tasks.analyze_sentiment_with_ai", fake_analyze)
+    monkeypatch.setattr("app.tasks.analyze_sentiment_and_emotions", fake_analyze)
     from backend.app.celery_app import celery_app
     celery_app.conf.task_always_eager = True
 
@@ -62,6 +62,7 @@ def test_process_journal_sentiment(db, monkeypatch):
     session.close()
     assert updated.sentiment_score == 1.0
     assert updated.key_emotions == "happy"
+    assert updated.primary_emotion == "happy"
 
 
 def test_process_chat_sentiment(db, monkeypatch):
@@ -69,9 +70,9 @@ def test_process_chat_sentiment(db, monkeypatch):
     msg = crud.chat_message.create_with_owner(db, obj_in=schemas.ChatMessageCreate(text="hi", is_user=True, timestamp=1), owner_id=user.id)
 
     async def fake_analyze(text: str):
-        return {"sentiment_score": -0.5, "key_emotions": "sad"}
+        return {"sentiment_score": -0.5, "emotions": "sad", "primary_emotion": "sad"}
 
-    monkeypatch.setattr("app.tasks.analyze_sentiment_with_ai", fake_analyze)
+    monkeypatch.setattr("app.tasks.analyze_sentiment_and_emotions", fake_analyze)
     from backend.app.celery_app import celery_app
     celery_app.conf.task_always_eager = True
 
@@ -82,3 +83,4 @@ def test_process_chat_sentiment(db, monkeypatch):
     session.close()
     assert updated.sentiment_score == -0.5
     assert updated.key_emotions == "sad"
+    assert updated.primary_emotion == "sad"

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -93,7 +93,7 @@ def test_chat_context_assembly(client, monkeypatch):
         return None
 
     monkeypatch.setattr(
-        "app.api.v1.endpoints.chat.analyze_sentiment_with_ai", fake_analyze
+        "app.api.v1.endpoints.chat.analyze_sentiment_and_emotions", fake_analyze
     )
     from app.tasks import process_chat_sentiment, process_journal_sentiment
 
@@ -164,7 +164,7 @@ def test_prompt_context_assembly(client, monkeypatch):
         return None
 
     monkeypatch.setattr(
-        "app.api.v1.endpoints.chat.analyze_sentiment_with_ai", fake_analyze
+        "app.api.v1.endpoints.chat.analyze_sentiment_and_emotions", fake_analyze
     )
     from app.tasks import process_chat_sentiment, process_journal_sentiment
 

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -93,8 +93,11 @@ def test_websocket_chat(client, monkeypatch):
         "app.api.v1.endpoints.chat.generate_pure_response", fake_generate
     )
     monkeypatch.setattr("app.api.v1.endpoints.chat.analyze_message", fake_analysis)
+    async def fake_sentiment_none(*a, **k):
+        return None
+
     monkeypatch.setattr(
-        "app.api.v1.endpoints.chat.analyze_sentiment_with_ai", lambda *a, **k: None
+        "app.api.v1.endpoints.chat.analyze_sentiment_and_emotions", fake_sentiment_none
     )
 
     with client.websocket_connect(f"/api/v1/chat/ws?token={token}") as ws:


### PR DESCRIPTION
## Summary
- implement `analyze_sentiment_and_emotions` service using httpx
- extend DB models and schemas with `primary_emotion`
- switch Celery tasks to new analyzer
- store emotion analysis in chat endpoints
- adjust tests for new analyzer output

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565861e50083248c64f0d6d3209d28