### PR TITLE
Add missing migration for primary emotion columns

### DIFF
--- a/backend/alembic/versions/0008_add_primary_emotion.py
+++ b/backend/alembic/versions/0008_add_primary_emotion.py
@@ -1,0 +1,19 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0008'
+down_revision = '0007'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('journalentries', sa.Column('primary_emotion', sa.String(), nullable=True))
+    op.add_column('chatmessages', sa.Column('primary_emotion', sa.String(), nullable=True))
+    op.add_column('emotion_logs', sa.Column('primary_emotion', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('emotion_logs', 'primary_emotion')
+    op.drop_column('chatmessages', 'primary_emotion')
+    op.drop_column('journalentries', 'primary_emotion')


### PR DESCRIPTION
## Summary
- add Alembic migration 0008_add_primary_emotion to support new columns

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c1668c448324bf10b9a212331dae