### PR TITLE
Run migrations automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Dear Diary provides daily journaling, mood tracking and AI-assisted conversation
 - Chat interface using AI models
 - Mood calendar and statistics
 - Voice journal and media library
+- Automatic database migrations on API startup
 
 ## Tech Stack
 
@@ -50,10 +51,9 @@ source .venv/bin/activate
 pip install -r backend/requirements.txt
 ```
 
-2. Apply database migrations and start services:
+2. Start the services (migrations run automatically on API startup):
 
 ```bash
-alembic -c backend/alembic.ini upgrade head
 uvicorn backend.main:app --reload
 celery -A backend.app.celery_app.celery_app worker --loglevel=info
 ```

--- a/backend/app/db/migrations.py
+++ b/backend/app/db/migrations.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import site
+import sys
+
+
+def upgrade_to_latest() -> None:
+    """Apply all pending Alembic migrations."""
+    for p in site.getsitepackages():
+        if p in sys.path:
+            sys.path.remove(p)
+        sys.path.insert(0, p)
+    for module in list(sys.modules):
+        if module.startswith("alembic"):
+            sys.modules.pop(module)
+    from alembic.config import Config
+    from alembic import command
+
+    root = Path(__file__).resolve().parents[2]
+    cfg_path = root / "alembic.ini"
+    cfg = Config(str(cfg_path))
+    cfg.set_main_option("script_location", str(root / "alembic"))
+    command.upgrade(cfg, "head")

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,11 +7,17 @@ log_setup.setup_logging()
 from fastapi import FastAPI
 from app.api.v1.api import api_router
 from app.core.config import settings
+from app.db.migrations import upgrade_to_latest
 # Database schema now managed via Alembic migrations
 
 app = FastAPI(title=settings.PROJECT_NAME)
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
+
+@app.on_event("startup")
+def run_migrations() -> None:
+    """Ensure database schema is up to date."""
+    upgrade_to_latest()
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## Summary
- add a small migrations helper
- call migration helper on FastAPI startup
- document automatic migration behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856c34d15f0832488d6cd9ff33aca34