### PR TITLE
Improve planner error handling

### DIFF
--- a/backend/tests/test_conversation_planner.py
+++ b/backend/tests/test_conversation_planner.py
@@ -72,7 +72,7 @@ def test_plan_conversation_strategy_api_error(monkeypatch):
         "app.services.conversation_planner.httpx.AsyncClient", DummyClient
     )
     plan = asyncio.run(plan_conversation_strategy("ctx", "hi"))
-    assert plan is None
+    assert plan.technique == CommunicationTechnique.PROBING
 
 
 def test_plan_conversation_strategy_unknown(monkeypatch):
@@ -421,7 +421,38 @@ def test_plan_conversation_strategy_missing_key(monkeypatch):
         "app.services.conversation_planner.httpx.AsyncClient", DummyClient
     )
     plan = asyncio.run(plan_conversation_strategy("ctx", "hi"))
-    assert plan is None
+    assert plan.technique == CommunicationTechnique.PROBING
+
+
+def test_plan_conversation_strategy_invalid_type(monkeypatch):
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, headers=None, json=None, timeout=None):
+            class Resp:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {
+                        "choices": [
+                            {
+                                "message": {"content": '{"technique": 123}'}
+                            }
+                        ]
+                    }
+
+            return Resp()
+
+    monkeypatch.setattr(
+        "app.services.conversation_planner.httpx.AsyncClient", DummyClient
+    )
+    plan = asyncio.run(plan_conversation_strategy("ctx", "hi"))
+    assert plan.technique == CommunicationTechnique.PROBING
 
 
 def test_plan_conversation_strategy_connection_failure(monkeypatch):


### PR DESCRIPTION
## Summary
- handle non-string techniques in conversation planner
- return fallback technique when API call returns HTTP error
- update planner tests for new fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856cf75d080832495964939b902acd5