### PR TITLE
Fix technique parsing in conversation planner

### DIFF
--- a/backend/app/services/conversation_planner.py
+++ b/backend/app/services/conversation_planner.py
@@ -1,6 +1,5 @@
 import json
 import importlib.resources
-import os
 import httpx
 import structlog
 import yaml
@@ -165,6 +164,7 @@ Pesan pengguna:\n{user_message}
                 )
                 tech_enum = determine_fallback_technique(previous_ai_text)
             else:
+                technique_str = technique_str.strip()
                 lower = technique_str.lower()
                 tech_enum = SYNONYMS.get(lower)
                 if tech_enum is None:


### PR DESCRIPTION
## Summary
- trim whitespace from AI planner technique suggestions
- remove unused `os` import

## Testing
- `pytest backend/tests/test_conversation_planner.py::test_plan_conversation_strategy_invalid_type -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d468a1908324a5ec55269c284061